### PR TITLE
cache: set sticky bit too to the children dirs

### DIFF
--- a/kiss
+++ b/kiss
@@ -130,7 +130,9 @@ pkg_sources() {
     # Store each downloaded source in named after the package it
     # belongs to. This avoid conflicts between two packages having a
     # source of the same name.
-    mkdir -p "$src_dir/$1" && cd "$src_dir/$1"
+    mkdir -p "$src_dir/$1"
+    chmod "$src_dir/$1"
+    cd "$src_dir/$1"
 
     # Find the package's repository files. This needs to keep
     # happening as we can't store this data in any kind of data
@@ -1027,6 +1029,9 @@ main() {
              "${src_dir:=$cac_dir/sources}" \
              "${bin_dir:=$cac_dir/bin}" \
         || die "Couldn't create cache directories."
+
+    # Set sticky bit in the "permanent" directories so users can write to it.
+    chmod 1777 "$cac_dir" "$src_dir" "$bin_dir"
 
     args "$@"
 }


### PR DESCRIPTION
I actually forgot that the sticky bit only applies to the "mother" cache directory and doesn't work recursively (with the "main dirs") where the files are created (`$cac_dir/sources` and `$cac_dir/bin`).

**Why `chmod`? Why not `mkdir -m`?**

This is to ensure that when user upgrades (`kiss u`), the change should be applied instead of releasing yet another chroot.