### PR TITLE
kiss: remove fakeroot usage

### DIFF
--- a/kiss
+++ b/kiss
@@ -382,11 +382,9 @@ pkg_tar() {
     # Read the version information to name the package.
     read -r version release < "$repo_dir/version"
 
-    # Create a tar-ball from the contents of the built package. `fakeroot`
-    # is used here to correct issues with file ownership.
-    fakeroot \
-        tar zpcf "$bin_dir/$1#$version-$release.tar.gz" -C "$pkg_dir/$1" . ||
-            die "[$1] Failed to create tar-ball"
+    # Create a tar-ball from the contents of the built package.
+    tar zpcf "$bin_dir/$1#$version-$release.tar.gz" -C "$pkg_dir/$1" . ||
+        die "[$1] Failed to create tar-ball"
 
     log "[$1] Successfully created tar-ball"
 }
@@ -514,7 +512,7 @@ pkg_build() {
 
         # Move to the build directory and call the build script.
         cd "$mak_dir/$pkg"
-        fakeroot "$repo_dir/build" "$pkg_dir/$pkg" ||
+        "$repo_dir/build" "$pkg_dir/$pkg" ||
             die "[$pkg] Build failed"
 
         # Copy the repository files to the package directory.
@@ -775,7 +773,8 @@ pkg_install() {
 
         # This is repeated multiple times. Better to make it a function.
         pkg_rsync() {
-            rsync -HKav --exclude etc -- "$tar_dir/$pkg_name/" "$KISS_ROOT/"
+            rsync --chown=root:root -HKav --exclude etc -- \
+                "$tar_dir/$pkg_name/" "$KISS_ROOT/"
         }
 
         # Install the package by using 'rsync' and overwrite any existing files
@@ -784,7 +783,8 @@ pkg_install() {
 
         # If '/etc/' exists in the package, install it but don't overwrite.
         [ -d "$tar_dir/$pkg_name/etc" ] &&
-            rsync -HKav --ignore-existing "$tar_dir/$pkg_name/etc" "$KISS_ROOT/"
+            rsync --chown=root:root -HKav --ignore-existing \
+                "$tar_dir/$pkg_name/etc" "$KISS_ROOT/"
 
         # Remove any leftover files if this is an upgrade.
         [ "$old_manifest" ] && {


### PR DESCRIPTION
Build test checklist:

- [x] alsa-lib
- [x] alsa-utils
- [x] atk
- [x] autoconf
- [x] automake
- [x] baseinit
- [x] baselayout
- [x] binutils
- [x] bison
- [x] busybox
- [x] bzip2
- [x] ca-certificates
- [x] cairo
- [x] cbindgen
- [x] ccache
- [x] clang
- [x] cmake
- [x] cryptsetup
- [x] curl
- [x] dhcpcd
- [x] e2fsprogs
- [x] efibootmgr
- [x] efivar
- [x] eudev
- [x] expat
- [x] ffmpeg
- [x] file
- [x] firefox
- [x] flex
- [x] fontconfig
- [x] freetype-harfbuzz
- [x] fribidi
- [x] gcc
- [x] gdk-pixbuf
- [x] giflib
- [x] git
- [x] glib
- [x] go
- [x] gperf
- [x] grub
- [x] gtk+2
- [x] gtk+3
- [x] gzip
- [x] hicolor-icon-theme
- [x] iana-etc
- [x] imlib2
- [x] json-c
- [x] kiss
- [x] kiss-bootstrap
- [x] lame
- [x] libICE
- [x] libSM
- [x] libX11
- [x] libXScrnSaver
- [x] libXau
- [x] libXcomposite
- [x] libXcursor
- [x] libXdamage
- [x] libXext
- [x] libXfixes
- [x] libXfont2
- [x] libXft
- [x] libXi
- [x] libXinerama
- [x] libXmu
- [x] libXrandr
- [x] libXrender
- [x] libXt
- [x] libXtst
- [x] libXxf86vm
- [x] libaio
- [x] libass
- [x] libdrm
- [x] libelf
- [x] libepoxy
- [x] libevdev
- [x] libffi
- [x] libfontenc
- [x] libinput
- [x] libjpeg-turbo
- [x] libnl
- [x] libogg
- [x] libpciaccess
- [x] libpng
- [x] libressl
- [x] libtheora
- [x] libtool
- [x] libvorbis
- [x] libvpx
- [x] libwebp
- [x] libxcb
- [x] libxkbfile
- [x] libxml2
- [x] libxshmfence
- [x] libxslt
- [x] linux-firmware
- [x] linux-headers
- [x] llvm
- [x] lvm2
- [x] m4
- [x] make
- [x] mandoc
- [x] mesa
- [x] meson
- [x] mpv
- [x] mtdev
- [x] musl
- [x] nasm
- [x] ncurses
- [x] ninja
- [x] nodejs
- [x] openssh
- [x] opus
- [x] pango
- [x] pciutils
- [x] perl
- [x] pixman
- [x] pkgconf
- [x] popt
- [x] python
- [x] python-mako
- [x] python-setuptools
- [x] python2
- [x] rsync
- [x] rust
- [x] shared-mime-info
- [x] st
- [x] sudo
- [x] tiff
- [x] tzdata
- [x] util-linux
- [x] vim
- [x] wavpack
- [x] wpa_supplicant
- [x] x264
- [x] x265
- [x] xcb-proto
- [x] xcb-util
- [x] xcb-util-keysyms
- [x] xcb-util-wm
- [x] xf86-input-libinput
- [x] xinit
- [x] xkbcomp
- [x] xkeyboard-config
- [x] xorg-server
- [x] xorg-util-macros
- [x] xorgproto
- [x] xrdb
- [x] xset
- [x] xtrans
- [x] xvidcore
- [x] xz
- [x] yasm
- [x] zip
- [x] zlib
