### PR TITLE
Lax deps

### DIFF
--- a/kiss
+++ b/kiss
@@ -907,15 +907,6 @@ args() {
         r|remove)
             log "Removing packages"
 
-            # Create a list of each package's dependencies.
-            # for pkg; do pkg_depends "$pkg"; done
-
-            # Reverse the list of dependencies filtering out anything
-            # not explicitly set for removal.
-            # for pkg in $deps; do
-            #     contains "$*" "$pkg" && remove_pkgs="$pkg $remove_pkgs"
-            # done
-
             for pkg; do
                 pkg_list "$pkg" >/dev/null ||
                     die "[$pkg] Not installed"

--- a/kiss
+++ b/kiss
@@ -172,7 +172,7 @@ pkg_extract() {
 }
 
 pkg_depends() {
-    # Resolve all dependencies and install them in the right order.
+    # Resolve all dependencies and generate an ordered list.
 
     repo_dir=$(pkg_find "$1")
 
@@ -190,7 +190,7 @@ pkg_depends() {
 
         # After child dependencies are added to the list,
         # add the package which depends on them.
-        [ "$2" ] || deps="$deps $1 "
+        [ "$2" = explicit ] || deps="$deps $1 "
     }
 }
 
@@ -901,13 +901,35 @@ args() {
         ;;
 
         i|install)
-            for pkg; do pkg_install "$pkg"; done
+            # Create a list of each package's dependencies.
+            for pkg; do
+                case $pkg in
+                    *.tar.gz) deps="$deps $pkg " ;;
+                    *)        pkg_depends "$pkg" install
+                esac
+            done
+
+            # Filter the list, only installing explicit packages.
+            # The purpose of these two loops is to order the
+            # argument list based on dependence.
+            for pkg in $deps; do
+                contains "$*" "$pkg" && pkg_install "$pkg"
+            done
         ;;
 
         r|remove)
             log "Removing packages"
 
-            for pkg; do
+            # Create a list of each package's dependencies.
+            for pkg; do pkg_depends "$pkg" remove; done
+
+            # Reverse the list of dependencies filtering out anything
+            # not explicitly set for removal.
+            for pkg in $deps; do
+                contains "$*" "$pkg" && remove_pkgs="$pkg $remove_pkgs"
+            done
+
+            for pkg in $remove_pkgs; do
                 pkg_list "$pkg" >/dev/null ||
                     die "[$pkg] Not installed"
 

--- a/kiss
+++ b/kiss
@@ -179,7 +179,7 @@ pkg_depends() {
     # This does a depth-first search. The deepest dependencies are
     # listed first and then the parents in reverse order.
     contains "$deps" "$1" || {
-        # Filter out non-explicit and aleady installed dependencies.
+        # Filter out non-explicit, aleady installed dependencies.
         [ -z "$2" ] && (pkg_list "$1" >/dev/null) && return
 
         # Recurse through the dependencies of the child

--- a/kiss
+++ b/kiss
@@ -179,6 +179,9 @@ pkg_depends() {
     # This does a depth-first search. The deepest dependencies are
     # listed first and then the parents in reverse order.
     contains "$deps" "$1" || {
+        # Filter out non-explicit and aleady installed dependencies.
+        [ -z "$2" ] && (pkg_list "$1" >/dev/null) && return
+
         # Recurse through the dependencies of the child
         # packages. Keep doing this.
         while read -r dep _; do
@@ -364,17 +367,7 @@ pkg_build() {
             explicit=$(echo "$explicit" | sed "s/ $pkg / /g")
     done
 
-    # The dependency solver always lists all dependencies regardless of
-    # whether or not they are installed. Filter out installed dependencies.
-    for pkg in $deps $explicit; do
-        contains "$explicit_build" "$pkg" || {
-           pkg_list "$pkg" >/dev/null && continue
-        }
-
-        build="$build$pkg "
-    done
-
-    set -- $build
+    set -- $deps $explicit
 
     log "Building: $*"
 
@@ -908,35 +901,22 @@ args() {
         ;;
 
         i|install)
-            # Create a list of each package's dependencies.
-            for pkg; do
-                case $pkg in
-                    *.tar.gz) deps="$deps $pkg " ;;
-                    *)        pkg_depends "$pkg"
-                esac
-            done
-
-            # Filter the list, only installing explicit packages.
-            # The purpose of these two loops is to order the
-            # argument list based on dependence.
-            for pkg in $deps; do
-                contains "$*" "$pkg" && pkg_install "$pkg"
-            done
+            for pkg; do pkg_install "$pkg"; done
         ;;
 
         r|remove)
             log "Removing packages"
 
             # Create a list of each package's dependencies.
-            for pkg; do pkg_depends "$pkg"; done
+            # for pkg; do pkg_depends "$pkg"; done
 
             # Reverse the list of dependencies filtering out anything
             # not explicitly set for removal.
-            for pkg in $deps; do
-                contains "$*" "$pkg" && remove_pkgs="$pkg $remove_pkgs"
-            done
+            # for pkg in $deps; do
+            #     contains "$*" "$pkg" && remove_pkgs="$pkg $remove_pkgs"
+            # done
 
-            for pkg in $remove_pkgs; do
+            for pkg; do
                 pkg_list "$pkg" >/dev/null ||
                     die "[$pkg] Not installed"
 


### PR DESCRIPTION
This moves the check for installed dependencies into the solver itself allowing for the generation of smaller dependency lists. The previous method is naive and pulls in `make` dependencies which may not be needed.

The one problem with this change is that it will expose packages with incomplete dependencies lists (I found `xorg-server` has a `make` dependency on `xtrans` which the naive solver pulls in but the "smart" one doesn't).

TODO:

- [ ] Add ordering of arguments back to 'i'/'r'.