### PR TITLE
don't copy /etc/resolv.conf if file exists, don't rm it on clean

### DIFF
--- a/contrib/kiss-chroot
+++ b/contrib/kiss-chroot
@@ -20,7 +20,6 @@ clean() {
 
     log Cleaning leftover host files; {
         rm -f "$1/root/.ash_history"
-        rm -f "$1/etc/resolv.conf"
     }
 }
 
@@ -39,7 +38,7 @@ main() {
     }
 
     log Copying /etc/resolv.conf from host; {
-        cp /etc/resolv.conf "$1/etc"
+         [ ! -f "/$1/etc/resolv.conf" ] && cp /etc/resolv.conf "$1/etc"
     }
 
     log Entering chroot; {

--- a/contrib/kiss-chroot
+++ b/contrib/kiss-chroot
@@ -38,7 +38,7 @@ main() {
     }
 
     log Copying /etc/resolv.conf from host; {
-         [ ! -f "/$1/etc/resolv.conf" ] && cp /etc/resolv.conf "$1/etc"
+         [ -f "/$1/etc/resolv.conf" ] || cp /etc/resolv.conf "$1/etc"
     }
 
     log Entering chroot; {


### PR DESCRIPTION
Hi, I like this little script and find it useful for more than the first installation. It was frustrating that it kept removing my /etc/resolv.conf, so I wanted to suggest this minor edit to the script.

Thanks :)