### PR TITLE
Git support

### DIFF
--- a/kiss
+++ b/kiss
@@ -187,6 +187,8 @@ pkg_extract() {
         case $src in
             # Git repository with supplied commit hash.
             git+*\#*)
+                log "Checking out ${src##*#}"
+
                 git reset --hard "${src##*#}" ||
                     die "Commit hash ${src##*#} doesn't exist"
             ;;

--- a/kiss
+++ b/kiss
@@ -150,12 +150,18 @@ pkg_sources() {
             # This is a checksums check, skip it.
             [ "$2" ] && continue
 
-            repo_src=${src##git+}
-
             mkdir -p "$mak_dir/$1/$dest"
 
-            (cd "$mak_dir/$1/$dest" && git clone "${repo_src%#*}" .) ||
-                die "$1" "Failed to clone $src"
+            # Run in a subshell to keep variables local.
+            (
+                repo_src=${src##git+}
+
+                [ "${src##*#*}" ] && shallow=--depth=1
+
+                cd "$mak_dir/$1/$dest" &&
+                    git clone "${shallow:---}" "${repo_src%#*}" .
+
+            ) || die "$1" "Failed to clone $src"
 
         # Remote source.
         elif [ -z "${src##*://*}" ]; then

--- a/kiss
+++ b/kiss
@@ -597,8 +597,9 @@ pkg_checksums() {
         elif [ -f "$src_dir/$1/${src##*/}" ]; then
             src_path=$src_dir/$1
 
-        # File is a git repository, skip checksums.
+        # File is a git repository.
         elif [ -z "${src##git+*}" ]; then
+            printf '%-64s  %s\n' git "${src##*/}"
             continue
 
         # Die here if source for some reason, doesn't exist.

--- a/kiss
+++ b/kiss
@@ -140,10 +140,22 @@ pkg_sources() {
 
     repo_dir=$(pkg_find "$1")
 
-    while read -r src _ || [ "$src" ]; do
+    while read -r src dest || [ "$src" ]; do
         # Remote source (cached).
         if [ -f "${src##*/}" ]; then
             log "$1" "Found cached source '${src##*/}'"
+
+        # Remote git repository.
+        elif [ -z "${src##git+*}" ]; then
+            # This is a checksums check, skip it.
+            [ "$2" ] && continue
+
+            repo_src=${src##git+}
+
+            mkdir -p "$mak_dir/$1/$dest"
+
+            (cd "$mak_dir/$1/$dest" && git clone "${repo_src%#*}" .) ||
+                die "$1" "Failed to clone $src"
 
         # Remote source.
         elif [ -z "${src##*://*}" ]; then
@@ -173,6 +185,17 @@ pkg_extract() {
         mkdir -p "$mak_dir/$1/$dest" && cd "$mak_dir/$1/$dest"
 
         case $src in
+            # Git repository with supplied commit hash.
+            git+*\#*)
+                git reset --hard "${src##*#}" ||
+                    die "Commit hash ${src##*#} doesn't exist"
+            ;;
+
+            # Git repository.
+            git+*)
+                continue
+            ;;
+
             # Only 'tar' archives are currently supported for extraction.
             # Any other file-types are simply copied to '$mak_dir' which
             # allows for manual extraction.
@@ -565,6 +588,10 @@ pkg_checksums() {
         # File is remote and was downloaded.
         elif [ -f "$src_dir/$1/${src##*/}" ]; then
             src_path=$src_dir/$1
+
+        # File is a git repository, skip checksums.
+        elif [ -z "${src##git+*}" ]; then
+            continue
 
         # Die here if source for some reason, doesn't exist.
         else
@@ -997,7 +1024,7 @@ args() {
 
         c|checksum)
             for pkg; do pkg_lint    "$pkg"; done
-            for pkg; do pkg_sources "$pkg"; done
+            for pkg; do pkg_sources "$pkg" c; done
             for pkg; do
                 pkg_checksums "$pkg" > "$(pkg_find "$pkg")/checksums"
 


### PR DESCRIPTION
Source format:

```
# git+URL
git+https://github.com/dylanaraps/eiwd

# git+URL#hash
git+https://github.com/dylanaraps/eiwd#4a2d30bd1b053a9f1e4373d17c2ae6f3ccbc4148
```

- Checksums are skipped over for git sources.
- Checksums work as normal for non-git sources in the same package.
- No caching support (for obvious reasons)

Issues:

- The checksums file will be empty if no non-git sources exist.
- You still have to run `kiss c pkg` even if no non-git sources.