### PR TITLE
log: replace use of literal escape code error with printf %b

### DIFF
--- a/kiss
+++ b/kiss
@@ -15,17 +15,13 @@
 log() {
     # Print a message prettily.
     #
-    # This function uses the literal escape character (Ctrl+V+Escape) as
-    # a simple way of *safely* bypassing the escape sequence restrictions
-    # on 'printf %s'. Cheeky, I know.
-    #
-    # '\033[1;32m'      Set text to color '2' and make it bold.
-    # '\033[m':         Reset text formatting.
-    # '${3:-->}':       If the 3rd argument is missing, set prefix to '->'.
-    # '${2:+[1;3Xm}':   If the 2nd argument exists, set the text style of '$1'.
-    # '${2:+[m}':       If the 2nd argument exists, reset text formatting.
-    printf '\033[1;33m%s \033[m%s\033[m %s\n' \
-           "${3:-->}" "${2:+[1;36m}$1${2:+[m}" "$2"
+    # '\033[1;32m'        Set text to color '2' and make it bold.
+    # '\033[m':           Reset text formatting.
+    # '${3:-->}':         If the 3rd argument is missing, set prefix to '->'.
+    # '${2:+\033[1;3Xm}': If the 2nd argument exists, set text style of '$1'.
+    # '${2:+\033[m}':     If the 2nd argument exists, reset text formatting.
+    printf '\033[1;33m%s \033[m%b%s\033[m %s\n' \
+           "${3:-->}" "${2:+\033[1;36m}" "$1" "$2"
 }
 
 die() {


### PR DESCRIPTION
Removed comment about using the literal escape character. Changed the comments describing the arguments to include the added non-literal escape character, and modified them slightly to keep everything from going above 80 columns (which seems to be the desired limit).