### PR TITLE
kiss: Reverse permissions model

### DIFF
--- a/kiss
+++ b/kiss
@@ -45,6 +45,20 @@ prompt() {
     read -r _
 }
 
+drop_root() {
+    drop_to=$1
+    shift
+
+    case $(id -u) in
+        0)
+            log "Lowering permissions from (root -> $drop_to)"
+            su -c "$*" "$drop_to"
+        ;;
+
+        *) "$@" ;;
+    esac
+}
+
 pkg_lint() {
     # Check that each mandatory file in the package entry exists.
     log "$1" "Checking repository files"
@@ -530,8 +544,10 @@ pkg_build() {
 
         log "$pkg" "Starting build"
 
-        # Call the build script.
-        "$repo_dir/build" "$pkg_dir/$pkg" || die "$pkg" "Build failed"
+        # Call the build script and drop permissions to the
+        # original caller if needed.
+        drop_root "$OLDUSER" "$repo_dir/build" "$pkg_dir/$pkg" ||
+            die "$pkg" "Build failed"
 
         # Copy the repository files to the package directory.
         # This acts as the database entry.
@@ -876,10 +892,15 @@ pkg_updates() {
 
             log "$PWD" "$signed "
 
+            # Find out the owner of the repository and spawn
+            # git as this user below.
+            repo_owner=$(stat -c %U "$PWD")
+
             # Lower permissions to the owner of the repository
             # to prevent changing permissions of files during
             # the pull process.
-            su -c 'git fetch && git merge' "$(stat -c %U "$PWD")"
+            drop_root "$repo_owner" git fetch
+            drop_root "$repo_owner" git merge
         }
     done
 
@@ -912,7 +933,7 @@ pkg_updates() {
 
         # Lower permissions to the original caller of kiss
         # to prevent builds from happening as root.
-        su -c 'kiss b kiss' "$OLDUSER"
+        drop_root "$OLDUSER" kiss b kiss
         pkg_install kiss
 
         log "Updated the package manager"

--- a/kiss
+++ b/kiss
@@ -467,8 +467,7 @@ pkg_build() {
             # to 'su' to elevate permissions.
             [ -f "$bin_dir/$pkg#$version-$release.tar.gz" ] && {
                 log "$pkg" "Found pre-built binary, installing"
-                (KISS_FORCE=1 \
-                    pkg_install "$bin_dir/$pkg#$version-$release.tar.gz")
+                (KISS_FORCE=1 args i "$bin_dir/$pkg#$version-$release.tar.gz")
 
                 # Remove the now installed package from the build
                 # list. No better way than using 'sed' in POSIX 'sh'.
@@ -555,7 +554,7 @@ pkg_build() {
         contains "$explicit" "$pkg" && [ -z "$pkg_update" ] && continue
 
         log "$pkg" "Needed as a dependency or has an update, installing"
-        (KISS_FORCE=1 pkg_install "$pkg")
+        (KISS_FORCE=1 args i "$pkg")
     done
 
     # End here as this was a system update and all packages have been installed.
@@ -573,7 +572,7 @@ pkg_build() {
         log "Install built packages? [$*]"
 
         prompt && {
-            pkg_install "$@"
+            args i "$@"
             return
         }
     }

--- a/kiss
+++ b/kiss
@@ -879,7 +879,7 @@ pkg_updates() {
             # Lower permissions to the owner of the repository
             # to prevent changing permissions of files during
             # the pull process.
-            su -c 'git fetch && git merge' - "$(stat -c %U "$PWD")"
+            su -c 'git fetch && git merge' "$(stat -c %U "$PWD")"
         }
     done
 

--- a/kiss
+++ b/kiss
@@ -997,17 +997,7 @@ args() {
             # Rerun the script with 'su' if the user isn't root.
             # Cheeky but 'su' can't be used on shell functions themselves.
             [ "$(id -u)" = 0 ] || {
-                if command -v sudo >/dev/null; then
-                    sudo -E OLDUSER="$OLDUSER" KISS_FORCE="$KISS_FORCE" \
-                        kiss "$action" "$@"
-
-                elif command -v doas >/dev/null; then
-                    OLDUSER="$OLDUSER" KISS_FORCE="$KISS_FORCE" \
-                        doas kiss "$action" "$@"
-                else
-                    su -pc "OLDUSER=$OLDUSER KISS_FORCE=$KISS_FORCE kiss $action $*"
-                fi
-
+                su -pc "OLDUSER=$OLDUSER KISS_FORCE=$KISS_FORCE kiss $action $*"
                 return
             }
         ;;

--- a/kiss
+++ b/kiss
@@ -467,7 +467,8 @@ pkg_build() {
             # to 'su' to elevate permissions.
             [ -f "$bin_dir/$pkg#$version-$release.tar.gz" ] && {
                 log "$pkg" "Found pre-built binary, installing"
-                (KISS_FORCE=1 args i "$bin_dir/$pkg#$version-$release.tar.gz")
+                (KISS_FORCE=1 \
+                    pkg_install "$bin_dir/$pkg#$version-$release.tar.gz")
 
                 # Remove the now installed package from the build
                 # list. No better way than using 'sed' in POSIX 'sh'.
@@ -554,7 +555,7 @@ pkg_build() {
         contains "$explicit" "$pkg" && [ -z "$pkg_update" ] && continue
 
         log "$pkg" "Needed as a dependency or has an update, installing"
-        (KISS_FORCE=1 args i "$pkg")
+        (KISS_FORCE=1 pkg_install "$pkg")
     done
 
     # End here as this was a system update and all packages have been installed.
@@ -572,7 +573,7 @@ pkg_build() {
         log "Install built packages? [$*]"
 
         prompt && {
-            args i "$@"
+            pkg_install "$@"
             return
         }
     }
@@ -910,8 +911,11 @@ pkg_updates() {
 
         prompt
 
-        pkg_build kiss
-        args i kiss
+        # Lower permissions to the owner of the repository
+        # to prevent changing permissions of files during
+        # the pull process.
+        su -c 'kiss b kiss' "$OLDUSER"
+        pkg_install kiss
 
         log "Updated the package manager"
         log "Re-run 'kiss update' to update your system"
@@ -987,15 +991,22 @@ args() {
             [ "$1" ] || [ -z "${action##u*}" ] ||
                 die "'kiss $action' requires an argument"
 
+            # Keep track of the original user to drop root permissions
+            # during builds. OLDUSER kinda mimics OLDPWD here.
+            [ "$OLDUSER" ] || OLDUSER=$USER
+
             # Rerun the script with 'su' if the user isn't root.
             # Cheeky but 'su' can't be used on shell functions themselves.
             [ "$(id -u)" = 0 ] || {
                 if command -v sudo >/dev/null; then
-                    sudo -E KISS_FORCE="$KISS_FORCE" kiss "$action" "$@"
+                    sudo -E OLDUSER="$OLDUSER" KISS_FORCE="$KISS_FORCE" \
+                        kiss "$action" "$@"
+
                 elif command -v doas >/dev/null; then
-                    KISS_FORCE="$KISS_FORCE" doas kiss "$action" "$@"
+                    OLDUSER="$OLDUSER" KISS_FORCE="$KISS_FORCE" \
+                        doas kiss "$action" "$@"
                 else
-                    su -pc "KISS_FORCE=$KISS_FORCE kiss $action $*"
+                    su -pc "OLDUSER=$OLDUSER KISS_FORCE=$KISS_FORCE kiss $action $*"
                 fi
 
                 return

--- a/kiss
+++ b/kiss
@@ -911,9 +911,8 @@ pkg_updates() {
 
         prompt
 
-        # Lower permissions to the owner of the repository
-        # to prevent changing permissions of files during
-        # the pull process.
+        # Lower permissions to the original caller of kiss
+        # to prevent builds from happening as root.
         su -c 'kiss b kiss' "$OLDUSER"
         pkg_install kiss
 

--- a/kiss
+++ b/kiss
@@ -1102,10 +1102,6 @@ args() {
             for pkg; do pkg_find "$pkg" all; done
         ;;
 
-        sources)
-            for pkg; do pkg_sources "$pkg"; done
-        ;;
-
         v|version|-v|--version)
             log kiss 0.70.0
         ;;
@@ -1121,6 +1117,10 @@ args() {
             log 'update:    Check for updates'
             log 'version:   Package manager version'
         ;;
+
+        # These are more or less for internal use. You may
+        # find them useful, however.
+        sources) for pkg; do pkg_sources "$pkg"; done ;;
 
         *) die "'kiss $action' is not a valid command" ;;
     esac

--- a/kiss
+++ b/kiss
@@ -996,7 +996,12 @@ args() {
             # Rerun the script with 'su' if the user isn't root.
             # Cheeky but 'su' can't be used on shell functions themselves.
             [ "$(id -u)" = 0 ] || {
-                su -pc "OLDUSER=$OLDUSER KISS_FORCE=$KISS_FORCE kiss $action $*"
+                log "Elevating permissions from ($USER -> root)"
+
+                su -pc "OLDUSER=\"$OLDUSER\" \
+                        KISS_FORCE=\"$KISS_FORCE\" \
+                        KISS_PATH=\"$KISS_PATH\"
+                        kiss $action $*"
                 return
             }
         ;;

--- a/kiss
+++ b/kiss
@@ -504,7 +504,8 @@ pkg_build() {
     # Die here as packages without checksums were found above.
     [ "$no_sums" ] && die "Checksums missing, run 'kiss checksum ${no_sums% }'"
 
-    for pkg; do pkg_sources "$pkg"; done
+    # Download all sources using the original calling user.
+    drop_root "$OLDUSER" kiss sources "$@"
 
     # Verify all package checksums. This is achieved by generating
     # a new set of checksums and then comparing those with the old
@@ -848,7 +849,6 @@ pkg_updates() {
     # Check all installed packages for updates. So long as the installed
     # version and the version in the repositories differ, it's considered
     # an update.
-
     log "Updating repositories"
 
     # Create a list of all repositories.
@@ -1100,6 +1100,10 @@ args() {
 
         s|search)
             for pkg; do pkg_find "$pkg" all; done
+        ;;
+
+        sources)
+            for pkg; do pkg_sources "$pkg"; done
         ;;
 
         v|version|-v|--version)

--- a/kiss
+++ b/kiss
@@ -49,14 +49,10 @@ drop_root() {
     drop_to=$1
     shift
 
-    case $(id -u) in
-        0)
-            log "Lowering permissions from (root -> $drop_to)"
-            su -c "$*" "$drop_to"
-        ;;
+    [ "$(id -u)" = 0 ] || { "$@"; return; }
 
-        *) "$@" ;;
-    esac
+    log "Lowering permissions from (root -> $drop_to)"
+    su -c "$*" "$drop_to"
 }
 
 pkg_lint() {

--- a/kiss
+++ b/kiss
@@ -876,22 +876,10 @@ pkg_updates() {
 
             log "$PWD" "$signed "
 
-            if [ -w "$PWD" ]; then
-                git fetch
-                git merge
-            else
-                log "$PWD" "Need root to update"
-
-                if command -v sudo >/dev/null; then
-                    sudo git fetch
-                    sudo git merge
-                elif command -v doas >/dev/null; then
-                    doas git fetch
-                    doas git merge
-                else
-                    su -c 'git fetch && git merge'
-                fi
-            fi
+            # Lower permissions to the owner of the repository
+            # to prevent changing permissions of files during
+            # the pull process.
+            su -c 'git fetch && git merge' - "$(stat -c %U "$PWD")"
         }
     done
 
@@ -995,8 +983,9 @@ args() {
             [ "$1" ] || die "'kiss $action' requires an argument"
         ;;
 
-        i|install|r|remove)
-            [ "$1" ] || die "'kiss $action' requires an argument"
+        i|install|r|remove|u|update)
+            [ "$1" ] || [ -z "${action##u*}" ] ||
+                die "'kiss $action' requires an argument"
 
             # Rerun the script with 'su' if the user isn't root.
             # Cheeky but 'su' can't be used on shell functions themselves.


### PR DESCRIPTION
The purpose of this PR is to reverse the permission model used for builds/updates. Instead of running `kiss u`/`kiss b` with countless password prompts, the package manager will prompt once, run as `root` and lower permissions where needed.

Issues: 

- [x] ~~`su` runs `sh` as a login shell and `.profile` is executed. This breaks the process when the user has anything interactive running at login. Figure out how to disable this.~~
- [x] ~~Ensure that `KISS_PATH` and friends are passed along to the elevated package manager instance.~~
- [ ] Drop root for all file operations and the build.

Blockers:

- [ ] Can't drop permissions to a single function.