### PR TITLE
kiss: Add option to show diffs on update

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ export KISS_RM=usr/share/doc:usr/share/gtk-doc:usr/share/info:usr/share/polkit-1
 # Set it to '1' to force.
 export KISS_FORCE=0
 
+# Show diff on system updates.
+#
+# This will spawn '$PAGER' (fallback to 'less') with a diff
+# of each changed file in the system update.
+#
+# Set it to '1' to enable.
+export KISS_AUDIT=0
+
 # Hook into kiss through a script.
 #
 # This can be used set custom CFLAGS per package, modify builds,

--- a/kiss
+++ b/kiss
@@ -1147,11 +1147,16 @@ pkg_updates() {
 
     # Show a diff of each new change to the repositories.
     # This spawns the user's set PAGER with a fallback to less.
+    #
+    # Disable this warning as the behavior (C may run when A is true)
+    # is intentional and fine. It is to prevent pager error from
+    # causing the package manager to abort.
+    # shellcheck disable=2015
     [ -s "$log_file" ] && {
         log "Saved update log to $log_file"
 
         [ "$KISS_AUDIT" ] && "${PAGER:-less}" "$log_file"
-    }
+    } ||:
 
     # Tell 'pkg_build' to always prompt before build.
     pkg_update=1

--- a/kiss
+++ b/kiss
@@ -1034,6 +1034,11 @@ pkg_updates() {
     # shellcheck disable=2046,2086
     { IFS=:; set -- $KISS_PATH; IFS=$old_ifs; }
 
+    # Where to store repository diffs for the update.
+    # At the same time, create the file so updates requiring root don't
+    # overwrite the user's existing permissions over the log.
+    :> "${log_file:=$log_dir/update-$time-$pid}"
+
     # Update each repository in '$KISS_PATH'. It is assumed that
     # each repository is 'git' tracked.
     for repo; do
@@ -1065,6 +1070,7 @@ pkg_updates() {
 
             if [ -w "$PWD" ] && [ "$(id -u)" != 0 ]; then
                 git fetch
+                git diff >> "$log_file"
                 git merge
 
             else
@@ -1078,12 +1084,15 @@ pkg_updates() {
                 # case that the repository is owned by a 3rd user.
                 (
                     user=$(stat -c %U "$PWD")
+                    pull="git fetch && git diff >>'$log_file' && git merge"
 
                     [ "$user" = root ] ||
                         log "Dropping permissions to $user for pull"
 
-                    as_root git fetch
-                    as_root git merge
+                    case $su in
+                        su) as_root       "$pull" ;;
+                        *)  as_root sh -c "$pull" ;;
+                    esac
                 )
             fi
         }
@@ -1135,6 +1144,14 @@ pkg_updates() {
     }
 
     log "Packages to update: ${outdated% }"
+
+    # Show a diff of each new change to the repositories.
+    # This spawns the user's set PAGER with a fallback to less.
+    [ -s "$log_file" ] && {
+        log "Saved update log to $log_file"
+
+        [ "$KISS_AUDIT" ] && "${PAGER:-less}" "$log_file"
+    }
 
     # Tell 'pkg_build' to always prompt before build.
     pkg_update=1

--- a/kiss
+++ b/kiss
@@ -1147,7 +1147,8 @@ pkg_updates() {
 
     # Show a diff of each new change to the repositories.
     # This spawns the user's set PAGER with a fallback to less.
-    [ "$KISS_AUDIT" ] && "${PAGER:-less}" "$mak_dir/log"
+    [ -s "$mak_dir/log" ] && [ "$KISS_AUDIT" = 1 ] &&
+        "${PAGER:-less}" "$mak_dir/log"
 
     # Tell 'pkg_build' to always prompt before build.
     pkg_update=1

--- a/kiss
+++ b/kiss
@@ -1037,7 +1037,7 @@ pkg_updates() {
     # Where to store repository diffs for the update.
     # At the same time, create the file so updates requiring root don't
     # overwrite the user's existing permissions over the log.
-    :> "${log_file:=$log_dir/update-$time-$pid}"
+    :> "$mak_dir/log"
 
     # Update each repository in '$KISS_PATH'. It is assumed that
     # each repository is 'git' tracked.
@@ -1070,7 +1070,7 @@ pkg_updates() {
 
             if [ -w "$PWD" ] && [ "$(id -u)" != 0 ]; then
                 git fetch
-                git diff >> "$log_file"
+                git diff >> "$mak_dir/log"
                 git merge
 
             else
@@ -1084,7 +1084,7 @@ pkg_updates() {
                 # case that the repository is owned by a 3rd user.
                 (
                     user=$(stat -c %U "$PWD")
-                    pull="git fetch && git diff >>'$log_file' && git merge"
+                    pull="git fetch && git diff >>'$mak_dir/log' && git merge"
 
                     [ "$user" = root ] ||
                         log "Dropping permissions to $user for pull"
@@ -1147,16 +1147,7 @@ pkg_updates() {
 
     # Show a diff of each new change to the repositories.
     # This spawns the user's set PAGER with a fallback to less.
-    #
-    # Disable this warning as the behavior (C may run when A is true)
-    # is intentional and fine. It is to prevent pager error from
-    # causing the package manager to abort.
-    # shellcheck disable=2015
-    [ -s "$log_file" ] && {
-        log "Saved update log to $log_file"
-
-        [ "$KISS_AUDIT" ] && "${PAGER:-less}" "$log_file"
-    } ||:
+    [ "$KISS_AUDIT" ] && "${PAGER:-less}" "$mak_dir/log"
 
     # Tell 'pkg_build' to always prompt before build.
     pkg_update=1

--- a/kiss.1
+++ b/kiss.1
@@ -63,7 +63,7 @@ export KISS_RM=usr/share/doc:usr/share/gtk-doc:usr/share/info:usr/share/polkit-1
 # Set it to '1' to force.
 export KISS_FORCE=0
 
-# Show diffs on system updates.
+# Show diff on system updates.
 #
 # This will spawn '$PAGER' (fallback to 'less') with a diff
 # of each changed file in the system update.

--- a/kiss.1
+++ b/kiss.1
@@ -63,6 +63,14 @@ export KISS_RM=usr/share/doc:usr/share/gtk-doc:usr/share/info:usr/share/polkit-1
 # Set it to '1' to force.
 export KISS_FORCE=0
 
+# Show diffs on system updates.
+#
+# This will spawn '$PAGER' (fallback to 'less') with a diff
+# of each changed file in the system update.
+#
+# Set it to '1' to enable.
+export KISS_AUDIT=0
+
 # Hook into kiss through a script.
 #
 # This can be used set custom CFLAGS per package, modify builds,


### PR DESCRIPTION
- The package manager will now optionally show a  `diff` of all changes in the current `kiss update`. 
- The user's set `$PAGER` will be called with a fallback to `less`.
- This is opt-in via the `KISS_AUDIT` environment variable (*set it to 1*). 