### PR TITLE
Add a command just for fetching remote repositories

### DIFF
--- a/kiss
+++ b/kiss
@@ -1062,10 +1062,7 @@ pkg_install() {
     log "$pkg_name" "Installed successfully"
 }
 
-pkg_updates() {
-    # Check all installed packages for updates. So long as the installed
-    # version and the version in the repositories differ, it's considered
-    # an update.
+pkg_fetch() {
     log "Updating repositories"
 
     # Create a list of all repositories.
@@ -1131,6 +1128,13 @@ pkg_updates() {
             fi
         }
     done
+}
+
+pkg_updates(){
+    # Check all installed packages for updates. So long as the installed
+    # version and the version in the repositories differ, it's considered
+    # an update.
+    pkg_fetch
 
     log "Checking for new package versions"
 
@@ -1296,6 +1300,8 @@ args() {
             done
         ;;
 
+        f|fetch) pkg_fetch ;;
+
         i|install)
             pkg_order "$@"
 
@@ -1316,10 +1322,11 @@ args() {
         v|version) log kiss 1.7.7 ;;
 
         h|help|-h|--help|'')
-            log 'kiss [a|b|c|i|l|r|s|u|v] [pkg] [pkg] [pkg]'
+            log 'kiss [a|b|c|f|i|l|r|s|u|v] [pkg] [pkg] [pkg]'
             log 'alternatives: List and swap to alternatives'
             log 'build:        Build a package'
             log 'checksum:     Generate checksums'
+            log 'fetch:        Fetch repositories'
             log 'install:      Install a package'
             log 'list:         List installed packages'
             log 'remove:       Remove a package'


### PR DESCRIPTION
I wanted to have an option for updating repositories without actually being asked to update packages.

This adds a function named `pkg_fetch`. `pkg-updates` function still uses this function, so there isn't much added code here.