### PR TITLE
pkg_conflicts: Fix error when KISS_ROOT is actually set

### DIFF
--- a/kiss
+++ b/kiss
@@ -680,7 +680,7 @@ pkg_conflicts() {
         printf '%s/%s\n' \
             "$(readlink -f "$KISS_ROOT/${file%/*}" 2>/dev/null)" \
             "${file##*/}"
-    done < "$tar_dir/$1/$sys_db/$1/manifest" > "$cac_dir/$pid-m"
+    done < "$tar_dir/$1/$pkg_db/$1/manifest" > "$cac_dir/$pid-m"
 
     [ -s "$cac_dir/$pid-m" ] || return 0
 


### PR DESCRIPTION
Suspected issue: `KISS_ROOT` appears twice as `sys_db` also adds an instance of `KISS_ROOT`.

Possible fix: Use `pkg_db` instead of `sys_db`.

Sample actual log:
<pre>~ # KISS_ROOT=/root/fakeroot/ kiss i linux-headers
-> linux-headers Extracting /root/fakeroot//root/.cache/kiss/bin/linux-headers#5
.4.24-1.tar.gz
-> linux-headers Checking that all dependencies are installed
-> linux-headers Checking for package conflicts
<strong>/usr/bin/kiss: line 677: can't open /root/fakeroot//root/.cache/kiss/extract-208
19/linux-headers//root/fakeroot//var/db/kiss/installed/linux-headers/manifest: n
o such file</strong>
-> linux-headers Installing package incrementally
          5.18M 100%   68.55MB/s    0:00:00 (xfr#926, to-chk=0/975)
-> linux-headers Installed successfully</pre>
NOTES:
- `linux-headers` was built with the same `KISS_ROOT` set.
- The same issue is produced with `KISS_ROOT` set to a path not having leading and/or trailing slashes.