### PR TITLE
kiss: pkg_fixdeps(): Make diff work across diff-erent implementations

### DIFF
--- a/kiss
+++ b/kiss
@@ -436,8 +436,9 @@ pkg_fixdeps() {
 
     # Display a 'diff' of the new dependencies against
     # the old ones. '-N' treats non-existent files as blank.
-    diff "$dep_file" depends ||:
+    diff -U 3 "$dep_file" depends ||:
 
+    # Remove the package's depends file if it's empty.
     [ -s depends ] || rm -f depends 
 }
 


### PR DESCRIPTION
busybox `diff` only supports unified diffs (therefore, the `-u` option is not available). However, GNU `diff` supports more diff formats and is not unified by default. Fortunately, both supports the `-U [num]` option which is POSIX compliant. We set it to `3` as a unified diff has three lines of context by default.

https://pubs.opengroup.org/onlinepubs/9699919799/utilities/diff.html