### PR TITLE
kiss-chbuild: add function for extra pkg

### DIFF
--- a/contrib/kiss-chbuild
+++ b/contrib/kiss-chbuild
@@ -31,5 +31,10 @@ cd "${cac_dir:=$KISS_ROOT${XDG_CACHE_HOME:-$HOME/.cache}/kiss}"
 log "Creating temporary chroot"
 cp -a kiss-chroot "chroot-$$"
 
+[ -z "$KISS_CHROOT_CANDY" ] || {
+    export KISS_ROOT="$HOME/.cache/kiss/chroot-$$"
+    kiss i "$KISS_CHROOT_CANDY"
+}
+
 log "Entering chroot"
 su -c "kiss-chroot chroot-$$; rm -rf chroot-$$"


### PR DESCRIPTION
This is an idea to easily have big packages like cmake, llvm, rust, * available in a chroot.  
At the moment to have `cmake` available you have to set `KISS_CHROOT_CANDY="ncurses expat cmake"`  
So you have to watch out which dependencies your pkgs need and respect the order.
However it would be also nice so specify some the source path, but afaik we cant do this yet? 