### PR TITLE
kiss-chbuild: run checksum twice

### DIFF
--- a/contrib/kiss-chbuild
+++ b/contrib/kiss-chbuild
@@ -11,8 +11,8 @@ cd "${cac_dir:=$KISS_ROOT${XDG_CACHE_HOME:-$HOME/.cache}/kiss}"
     log "Downloading chroot tarball"
 
     url=https://github.com/kisslinux/repo/releases/download/1.10.0/
-    curl -OL "$url/kiss-chroot.tar.xz"
     curl -OL "$url/kiss-chroot.tar.xz.sha256"
+    curl -OL "$url/kiss-chroot.tar.xz"
 
     log "Verifying checksums"
 
@@ -21,6 +21,15 @@ cd "${cac_dir:=$KISS_ROOT${XDG_CACHE_HOME:-$HOME/.cache}/kiss}"
         log "Checksum verification failed."
         log "Re-run 'kiss-chbuild' to try again."
     }
+}
+
+log "Verifying checksums"
+
+sha256sum -c < kiss-chroot.tar.xz.sha256 || {
+    rm -f kiss-chroot.tar.xz
+    log "Checksum verification failed."
+    log "Re-run 'kiss-chbuild' to try again."
+    exit 0
 }
 
 [ -d kiss-chroot ] || {


### PR DESCRIPTION
I have tested the new kiss-chbuild, but it still fails when there is a fragmented download because the 
source is only deleted if the download went through.  
However if the download fails or you interrupt in manually there is no check.
I let the checksum run twice right before chrooting in to check again if the source is ok and if not error  
out and delete.
Also I switched the order of the downloads to  make sure the sha256 is there.