### PR TITLE
kiss: remove non-POSIX printf * field width specifier

### DIFF
--- a/kiss
+++ b/kiss
@@ -1519,7 +1519,7 @@ args() {
             done
 
             for path do
-                printf '%b->%b %-*s ' "$lcol" "$lclr" "$max" "${path#*/kiss-}"
+                printf "%b->%b %-${max}s " "$lcol" "$lclr" "${path#*/kiss-}"
                 sed -n 's/^# *//;2p' "$(command -v "kiss-$path")"
             done | sort -uk1 >&2
         ;;


### PR DESCRIPTION
POSIX doesn't specify %*s for the printf command, with the rationale
that one can just put the variable there in place, do that.