### PR TITLE
kiss: Don't create empty post-install log file

### DIFF
--- a/kiss
+++ b/kiss
@@ -1149,9 +1149,11 @@ pkg_install() {
     trap pkg_clean EXIT INT
 
     if [ -x "$sys_db/$pkg_name/post-install" ]; then
-        log "$pkg_name" "post-install log"
-        "$sys_db/$pkg_name/post-install"
-    fi 2>&1 | tee -a "$log_dir/post-install-$time-$pid" >/dev/null
+        {
+            log "$pkg_name" "post-install log"
+            "$sys_db/$pkg_name/post-install"
+        } 2>&1 | tee -a "$log_dir/post-install-$time-$pid"
+    fi
 
     run_hook post-install "$pkg_name" "$sys_db/$pkg_name"
 


### PR DESCRIPTION
This would prevent an empty post-install log file from being created if there is no post-install script or if it's not executable.