### PR TITLE
kiss: remove unsupported glyph ("✓")

### DIFF
--- a/kiss
+++ b/kiss
@@ -1189,7 +1189,7 @@ pkg_updates() {
             # Display a tick if signing is enabled for this
             # repository.
             case $(git config merge.verifySignatures) in
-                true) log "$PWD" "[signed ✓] " ;;
+                true) log "$PWD" "[signed] " ;;
                 *)    log "$PWD" " " ;;
             esac
 


### PR DESCRIPTION
Liberation fonts (i.e. Liberation Mono), which are available via `liberation-fonts` in the KISS main repository, do not support the "✓" glyph. No alternative or patched font sets are currently available in the main repo, so i think it makes sense to remove unsupported glyphs.

**source**: https://fonts2u.com/liberation-mono.font