### PR TITLE
Prototype tool for recursive dependency removal

### DIFF
--- a/contrib/kiss-lsdeps
+++ b/contrib/kiss-lsdeps
@@ -1,0 +1,35 @@
+#!/bin/sh -e
+# List packages that are dependencies of only the given packages
+
+[ "$1" ] && kiss s "$@" >/dev/null || {
+    printf 'usage: [kiss-deptree [pkg]...]\n'
+    exit 1
+}
+
+cd "$KISS_ROOT/var/db/kiss/installed"
+
+# Find all of the dependencies of given packages
+for pkg in $@; do
+    cat "./$1/depends" 2>/dev/null
+done | sort -u | while read -r _pkg _ 2>/dev/null; do
+    required=
+    # Check all dependants
+    for revdep in $(grep "^$_pkg" -- */depends); do
+        case "$@" in
+            # Depended on by a package that is going to be removed
+            # No problems putting it up as a removal candidate
+            "${revdep%%/depends:*} "*|\
+            *" ${revdep%%/depends:*} "*|\
+            *" ${revdep%%/depends:*}")
+            ;;
+            # Depended on by a package that is not being removed
+            # Not a candidate for removal
+            *)
+                required=yes
+                break
+            ;;
+        esac
+    done
+
+    [ "$required" = "yes" ] || printf '%s\n' "$_pkg"
+done | sort -u


### PR DESCRIPTION
(Forgot to mark it as draft PR, please consider it as such)

Not sure if this even is a feature that should be done, just an idea that popped into my head reading FAQ section 6.1 "Recursive dependency removal", which suggests a rather long approach.

For any given list of packages, it lists the packages that are dependencies of *only* those packages. In other words, packages that are not currently orphans, but will become orphans once the given packages are uninstalled.

The procedure to use it is:
 - Run with any package/s from orphans that you no longer need
 - From the output, choose the non-user-facing packages (that you no longer need)
 - Run with original arguments + the packages chosen in last step
 - Repeat last two steps until no new output is being returned
 - Run `kiss rem` with the packages

In its current form, this tool is pretty inconvinient to use because of all the typing. It would be pretty easy to make it into an iterative recursive loop, but then comes the problem of user-facing packages coming in somewhere. One possible solution is a simple y/n interactive prompt that asks the user whether they want to keep eacg newly found package in every iteration (which I am currently writing).

Would this tool be useful for users?      