### PR TITLE
Add CRUX style usage to contrib scripts

### DIFF
--- a/contrib/kiss-depends
+++ b/contrib/kiss-depends
@@ -1,9 +1,15 @@
 #!/bin/sh -ef
 # Display a package's dependencies
 
+# CRUX style usage using the current directory as the name of the package to be
+# operated on.
+[ "$1" ] || {
+    set -- "${PWD##*/}"
+}
+
 # Ignore shellcheck as we want the warning's behavior.
 # shellcheck disable=2015
-[ "$1" ] && kiss l "${1:-null}" >/dev/null || {
+kiss l "${1:-null}" >/dev/null || {
     printf 'usage: kiss-depends [pkg]\n'
     exit 1
 }

--- a/contrib/kiss-export
+++ b/contrib/kiss-export
@@ -1,9 +1,15 @@
 #!/bin/sh -ef
 # Turn an installed package into a KISS tarball
 
+# CRUX style usage using the current directory as the name of the package to be
+# operated on.
+[ "$1" ] || {
+    set -- "${PWD##*/}"
+}
+
 # Ignore shellcheck as we want the warning's behavior.
 # shellcheck disable=2015
-[ "$1" ] && kiss l "${1:-null}" >/dev/null || {
+kiss l "${1:-null}" >/dev/null || {
     printf 'usage: kiss-export [pkg]\n'
     exit 1
 }

--- a/contrib/kiss-maintainer
+++ b/contrib/kiss-maintainer
@@ -1,12 +1,14 @@
 #!/bin/sh -ef
 # Find the maintainer of a package
 
+# CRUX style usage using the current directory as the name of the package to be
+# operated on.
 [ "$1" ] || {
-    printf 'usage: kiss-maintainer [pkg]\n'
-    exit 1
+    export KISS_PATH=${PWD%/*}:$KISS_PATH
+    set -- "${PWD##*/}"
 }
 
-kiss s "$1" | while read -r repo; do cd "$repo"
+kiss s "$@" | sort -u | while read -r repo; do cd "$repo"
     m=$(git log -1 version 2>/dev/null) ||:
     m=${m##*Author: }
     m=${m%%>*}

--- a/contrib/kiss-manifest
+++ b/contrib/kiss-manifest
@@ -1,9 +1,15 @@
 #!/bin/sh -ef
 # Display all files owned by a package
 
+# CRUX style usage using the current directory as the name of the package to be
+# operated on.
+[ "$1" ] || {
+    set -- "${PWD##*/}"
+}
+
 # Ignore shellcheck as we want the warning's behavior.
 # shellcheck disable=2015
-[ "$1" ] && kiss l "${1:-null}" >/dev/null || {
+kiss l "${1:-null}" >/dev/null || {
     printf 'usage: kiss-manifest [pkg]\n'
     exit 1
 }

--- a/contrib/kiss-revdepends
+++ b/contrib/kiss-revdepends
@@ -1,11 +1,10 @@
 #!/bin/sh -e
 # Display packages which depend on package
 
-# Ignore shellcheck as we want the warning's behavior.
-# shellcheck disable=2015
+# CRUX style usage using the current directory as the name of the package to be
+# operated on.
 [ "$1" ] || {
-    printf 'usage: kiss-revdepends [pkg]\n'
-    exit 1
+    set -- "${PWD##*/}"
 }
 
 # 'cd' to the database directory as a simple way of

--- a/contrib/kiss-size
+++ b/contrib/kiss-size
@@ -15,9 +15,15 @@ get_size() {
     printf '%s\t%s\n' "$hum" "$2"
 }
 
+# CRUX style usage using the current directory as the name of the package to be
+# operated on.
+[ "$1" ] || {
+    set -- "${PWD##*/}"
+}
+
 # Ignore shellcheck as we want the warning's behavior.
 # shellcheck disable=2015
-[ "$1" ] && kiss l "${1:-null}" >/dev/null || {
+kiss l "${1:-null}" >/dev/null || {
     printf 'usage: kiss-size [pkg]\n'
     exit 1
 }


### PR DESCRIPTION
Using the current directory as the name of the package to be operated on, like how `kiss` does it. Besides this I made a small change to `kiss-maintainers`, it now allows multiple parameters, for example `kiss-maintainers git mpv`