### PR TITLE
Contrib cleanup

### DIFF
--- a/contrib/kiss-depends
+++ b/contrib/kiss-depends
@@ -8,7 +8,7 @@
 
 # Ignore shellcheck as we want the warning's behavior.
 # shellcheck disable=2015
-kiss l "${1:-null}" >/dev/null || {
+kiss list "${1:-null}" >/dev/null || {
     printf 'usage: kiss-depends [pkg]\n'
     exit 1
 }

--- a/contrib/kiss-depends
+++ b/contrib/kiss-depends
@@ -1,8 +1,7 @@
 #!/bin/sh -ef
 # Display a package's dependencies
 
-# CRUX style usage using the current directory as the name of the package to be
-# operated on.
+# Use the current directory as the package name if no package is given.
 [ "$1" ] || {
     set -- "${PWD##*/}"
 }

--- a/contrib/kiss-export
+++ b/contrib/kiss-export
@@ -8,7 +8,7 @@
 
 # Ignore shellcheck as we want the warning's behavior.
 # shellcheck disable=2015
-kiss l "${1:-null}" >/dev/null || {
+kiss list "${1:-null}" >/dev/null || {
     printf 'usage: kiss-export [pkg]\n'
     exit 1
 }

--- a/contrib/kiss-export
+++ b/contrib/kiss-export
@@ -13,7 +13,7 @@ kiss list "${1:-null}" >/dev/null || {
     exit 1
 }
 
-# Grab the package's version..
+# Grab the package's version.
 read -r ver rel 2>/dev/null < "$KISS_ROOT/var/db/kiss/installed/$1/version"
 
 # Reset the argument list.

--- a/contrib/kiss-export
+++ b/contrib/kiss-export
@@ -1,8 +1,7 @@
 #!/bin/sh -ef
 # Turn an installed package into a KISS tarball
 
-# CRUX style usage using the current directory as the name of the package to be
-# operated on.
+# Use the current directory as the package name if no package is given.
 [ "$1" ] || {
     set -- "${PWD##*/}"
 }

--- a/contrib/kiss-fork
+++ b/contrib/kiss-fork
@@ -3,7 +3,7 @@
 
 # Ignore shellcheck as we want the warning's behavior.
 # shellcheck disable=2015
-[ "$1" ] && kiss s "${1:-null}" >/dev/null || {
+[ "$1" ] && kiss search "${1:-null}" >/dev/null || {
     printf 'usage: [kiss-fork [pkg]] [index]\n'
     exit 1
 }
@@ -14,7 +14,7 @@ num=$2
 # is intentional. This grabs the location of the package's files.
 # shellcheck disable=2046
 (
-    set -- $(kiss s "$1")
+    set -- $(kiss search "$1")
 
     shift "${num:-0}"
 

--- a/contrib/kiss-link
+++ b/contrib/kiss-link
@@ -16,7 +16,7 @@ oPWD=$PWD
 # Check if the package exists in a repository and error out here
 # if it does not. The error message from the package manager will
 # be displayed.
-kiss s "${PWD##*/}" >/dev/null
+kiss search "${PWD##*/}" >/dev/null
 
 # Disable this warning as globbing is disabled and word splitting
 # is intentional. This grabs the location of the package's files.
@@ -25,7 +25,7 @@ kiss s "${PWD##*/}" >/dev/null
     # Generate a list of repositories in which the package
     # exists. Then 'cd' to the first found directory to do a
     # comparison.
-    set -- $(kiss s "${PWD##*/}"); cd "$1"
+    set -- $(kiss search "${PWD##*/}"); cd "$1"
 
     # Error if the package exists nowhere but the current
     # directory and this script would create a broken symlink.

--- a/contrib/kiss-maintainer
+++ b/contrib/kiss-maintainer
@@ -7,7 +7,7 @@
     set -- "${PWD##*/}"
 }
 
-kiss s "$@" | sort -u | while read -r repo; do cd "$repo"
+kiss search "$@" | uniq -u | while read -r repo; do cd "$repo"
     m=$(git log -1 version 2>/dev/null) ||:
     m=${m##*Author: }
     m=${m%%>*}

--- a/contrib/kiss-maintainer
+++ b/contrib/kiss-maintainer
@@ -1,8 +1,7 @@
 #!/bin/sh -ef
 # Find the maintainer of a package
 
-# CRUX style usage using the current directory as the name of the package to be
-# operated on.
+# Use the current directory as the package name if no package is given.
 [ "$1" ] || {
     export KISS_PATH=${PWD%/*}:$KISS_PATH
     set -- "${PWD##*/}"

--- a/contrib/kiss-manifest
+++ b/contrib/kiss-manifest
@@ -1,15 +1,14 @@
 #!/bin/sh -ef
 # Display all files owned by a package
 
-# CRUX style usage using the current directory as the name of the package to be
-# operated on.
+# Use the current directory as the package name if no package is given.
 [ "$1" ] || {
     set -- "${PWD##*/}"
 }
 
 # Ignore shellcheck as we want the warning's behavior.
 # shellcheck disable=2015
-kiss l "${1:-null}" >/dev/null || {
+kiss list "${1:-null}" >/dev/null || {
     printf 'usage: kiss-manifest [pkg]\n'
     exit 1
 }

--- a/contrib/kiss-outdated
+++ b/contrib/kiss-outdated
@@ -4,7 +4,7 @@
 # Intended behavior.
 # shellcheck disable=2106
 
-kiss s "${@:-*}" | (while read -r pkg_loc _; do {
+kiss search "${@:-*}" | (while read -r pkg_loc _; do {
     read -r ver _ 2>/dev/null < "$pkg_loc/version" || continue
 
     pkg=${pkg_loc##*/}

--- a/contrib/kiss-reset
+++ b/contrib/kiss-reset
@@ -17,5 +17,5 @@ done
 [ "$1" ] && {
     printf 'WARNING: This will remove \033[1m%s\033[m package(s).\n' "$#"
     printf 'Continue? [Enter/Ctrl+C]\n'
-    read -r _ && KISS_FORCE=1 kiss r "$@"
+    read -r _ && KISS_FORCE=1 kiss remove "$@"
 }

--- a/contrib/kiss-revdepends
+++ b/contrib/kiss-revdepends
@@ -1,8 +1,7 @@
 #!/bin/sh -e
 # Display packages which depend on package
 
-# CRUX style usage using the current directory as the name of the package to be
-# operated on.
+# Use the current directory as the package name if no package is given.
 [ "$1" ] || {
     set -- "${PWD##*/}"
 }

--- a/contrib/kiss-size
+++ b/contrib/kiss-size
@@ -15,8 +15,7 @@ get_size() {
     printf '%s\t%s\n' "$hum" "$2"
 }
 
-# CRUX style usage using the current directory as the name of the package to be
-# operated on.
+# Use the current directory as the package name if no package is given.
 [ "$1" ] || {
     set -- "${PWD##*/}"
 }

--- a/contrib/kiss-size
+++ b/contrib/kiss-size
@@ -22,7 +22,7 @@ get_size() {
 
 # Ignore shellcheck as we want the warning's behavior.
 # shellcheck disable=2015
-kiss l "${1:-null}" >/dev/null || {
+kiss list "${1:-null}" >/dev/null || {
     printf 'usage: kiss-size [pkg]\n'
     exit 1
 }


### PR DESCRIPTION
Some minor nitpicks for contrib scripts.

The biggest functional change is `sort -u` to `uniq -u`, which preserves ordering.