### PR TITLE
kiss: Add handling of /etc/ files to removal action.

### DIFF
--- a/kiss
+++ b/kiss
@@ -986,10 +986,15 @@ pkg_remove_files() {
     # installation and package removal. Combining the removals in these two
     # functions allows us to stop duplicating code.
     while read -r file; do
-        case $file in /etc/*)
-            printf 'Skipping removal of %s\n' "$file"
-            continue;
-        esac
+        case $file in /etc/?*[!/])
+            sum_sys=$(sh256 "$KISS_ROOT/$file")
+            sum_old=$(grep -F "$sum_sys" "$mak_dir/c")
+
+            [ "$sum_sys" = "$sum_old" ] || {
+                printf 'Skipping %s (modified)\n' "$file"
+                continue
+            }
+        esac 2>/dev/null ||:
 
         file=$KISS_ROOT/$file
 
@@ -1085,8 +1090,10 @@ pkg_remove() {
         "$sys_db/$1/pre-remove" ||:
     fi
 
-    log "$1" "Removing package"
+    # Make a backup of the etcsums file (if it exists).
+    cp -f "$sys_db/$1/etcsums" "$mak_dir/c" 2>/dev/null ||:
 
+    log "$1" "Removing package"
     pkg_remove_files < "$sys_db/$1/manifest"
 
     # Reset 'trap' to its original value. Removal is done so


### PR DESCRIPTION
If the user has modified the file in /etc/, it will not be removed
and a message will be printed to the screen. If the file is
unmodified, it will be removed like any other.

This uses the etcsums file for comparison of checksums. The file
is also used during installation handling of files in /etc/.

Closes #181 