### PR TITLE
kiss-graph: list all packages by size

### DIFF
--- a/contrib/kiss-graph
+++ b/contrib/kiss-graph
@@ -1,0 +1,8 @@
+#!/bin/sh -ef
+# list all packages by size
+export KISS_RAW=1
+kiss list | xargs -I{} -n 1 sh -c 'echo $(kiss size {} 2>&1 >/dev/null | cut -f 1,3) {}' | sort -k 2 -nr |
+while read -r hSize size pkg version rVersion; do
+    printf "%s\t%s\n" $hSize $pkg
+done
+

--- a/contrib/kiss-size
+++ b/contrib/kiss-size
@@ -12,7 +12,11 @@ get_size() {
         *)     hum=$(($1))  ;;
     esac
 
-    printf '%s\t%s\n' "$hum" "$2"
+    if [ -z "$KISS_RAW" ]; then
+        printf '%s\t%s\n' "$hum" "$2"
+    else
+        printf '%s\t%s\t%s\n' "$hum" "$2" "$1"
+    fi
 }
 
 # Use the current directory as the package name if no package is given.


### PR DESCRIPTION
I was looking for functionality like Arch's pacgraph where all installed packages would be listed by size. This patch adds a kiss extension that uses kiss-size to achieve similar functionality.

Since the default sort doesn't have an option to compare human readable numbers, an environmental var was added to kiss-size such that when it is set, the size is KB will be printed too so kiss-graph can use it to sort.

Example output:
```
137MB   gcc
44MB    perl
37MB    python
29MB    vim
27MB    binutils 
...
```