### PR TITLE
kiss: Expand $VERSION and $ARCH in source

### DIFF
--- a/kiss
+++ b/kiss
@@ -271,6 +271,8 @@ pkg_sources() {
     mkdir -p "$src_dir/$1"
     cd "$src_dir/$1"
 
+    read -r version release < "$repo_dir/version"
+    sed "s/\$VERSION/$version/g; s/\$ARCH/${ARCH:-$(uname -m)}/g" "$repo_dir/sources" |
     while read -r src dest || [ "$src" ]; do
         if [ -z "${src##\#*}" ]; then
             continue
@@ -299,7 +301,7 @@ pkg_sources() {
         else
             die "$1" "no local file '$src'"
         fi
-    done < "$repo_dir/sources"
+    done
 }
 
 pkg_extract() {
@@ -311,6 +313,8 @@ pkg_extract() {
 
     log "$1" "extracting sources"
 
+    read -r version release < "$repo_dir/version"
+    sed "s/\$VERSION/$version/g; s/\$ARCH/${ARCH:-$(uname -m)}/g" "$repo_dir/sources" |
     while read -r src dest || [ "$src" ]; do
         mkdir -p "$mak_dir/$1/$dest" && cd "$mak_dir/$1/$dest"
 
@@ -404,7 +408,7 @@ pkg_extract() {
                 fi
             ;;
         esac
-    done < "$repo_dir/sources"
+    done
 }
 
 pkg_depends() {


### PR DESCRIPTION
Expand variables VERSION and ARCH in source files so that they don't
have to be manually updated every version change. The ARCH field is
there to make installing prebuilt packages seamless across different
architectures when possible.

Wasn't sure if it would be better to just eval sources and expand all vars or just whitelist a few. Went with whitelisting because I don't expect there to be many vars people would want to access from sources.

Context about my use case for those that care:
I was creating a package and didn't want to go through the trouble of building it so I setup it up to download the binary. The URL required the version and arch. Version is already hard-coded and thought it would be neat to not need a separate package where the only change would be a few characters to support aarm64. Now can keep the package up-to-date by changing one file ideally.