### PR TITLE
kiss-preferred: new utility to list all current conflicts resolutions. 

### DIFF
--- a/contrib/kiss-preferred
+++ b/contrib/kiss-preferred
@@ -1,0 +1,7 @@
+#!/bin/sh -e
+# Lists the owners of all files with conflicts
+
+kiss a | sort -u -k2 | while read -r _ path; do
+    echo "$(kiss owns "$path")" "$path"
+done
+

--- a/kiss
+++ b/kiss
@@ -1441,7 +1441,7 @@ args() {
     #
     # This handles the globbing characters '*', '!', '[' and ']' as per:
     # https://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html
-    [ "${action##[as]*}" ] && case "$*" in *\**|*\!*|*\[*|*\]*)
+    [ "${action##[aos]*}" ] && case "$*" in *\**|*\!*|*\[*|*\]*)
         die "Arguments contain invalid characters: '!*[]' ($*)"
     esac
 


### PR DESCRIPTION
Wrote a small script to get the "in-use" file for every "alternative".

The goal is to be able to maintain the same software stack on multiple machines. Plan to take the output of this command on one machine and pipe into `kiss a` on another (assuming the same set of programs are installed).

When writing the extension, I noticed `kiss own '/usr/bin/['` didn't work, so this PR also includes the one line fix for that too.

Example output
```
./contrib/kiss-preferred | head -n4
busybox /usr/bin/[
busybox /usr/bin/base64
busybox /usr/bin/basename
busybox /usr/bin/blkdiscard
```
