### PR TITLE
kiss-export: new naming scheme for tarballs

### DIFF
--- a/contrib/kiss-export
+++ b/contrib/kiss-export
@@ -19,7 +19,7 @@ done < "$db/$pkg/manifest"
 
 cd "$KISS_ROOT/"
 
-dest="$OLDPWD/$pkg#$ver-$rel.tar.${KISS_COMPRESS:-gz}"
+dest="$OLDPWD/$pkg@$ver-$rel.tar.${KISS_COMPRESS:-gz}"
 
 tar cf - "$@" | case ${KISS_COMPRESS:-gz} in
     bz2)  bzip2 -z ;;


### PR DESCRIPTION
Follow kiss package manager new naming scheme in kiss-export also.