### PR TITLE
pkg_find: Don't search in "/"

### DIFF
--- a/kiss
+++ b/kiss
@@ -147,9 +147,11 @@ pkg_find() {
     # the repositories and secondly to allow for the query to be a glob.
     # shellcheck disable=2086
     for path in $KISS_PATH "${what:-$sys_db}"; do set +f
-        for path2 in "$path/"$query; do
-            test "${what:--d}" "$path2" && set -f -- "$@" "$path2"
-        done
+        [ "$path" != "" ] && {
+            for path2 in "$path/"$query; do
+                test "${what:--d}" "$path2" && set -f -- "$@" "$path2"
+            done
+        }
     done
 
     unset IFS


### PR DESCRIPTION
```
# mkdir /kiss
$ kiss b kiss
-> Resolving dependencies
-> Building: kiss
-> kiss Checking repository files
ERROR Version file not found

$ kiss s kiss
/kiss
/home/testuser/kiss/grepo/core/kiss
/var/db/kiss/installed/kiss

$ echo $KISS_PATH
:/home/testuser/kiss/kiss-repo/optim...
```