### PR TITLE
pkg_remove(): Fix reverse dependency resolving on sbase grep

### DIFF
--- a/kiss
+++ b/kiss
@@ -1123,7 +1123,7 @@ pkg_remove() {
     [ "$KISS_FORCE" = 1 ] || {
         log "$1" "Checking for reverse dependencies"
 
-        (cd "$sys_db"; set +f; grep -lFx "$1" -- */depends) &&
+        (cd "$sys_db"; set +f; grep -lFx -- "$1" */depends) &&
             die "$1" "Can't remove package, others depend on it"
     }
 


### PR DESCRIPTION
sbase utilities don't accept flags after arguments begin, meaning that
the '--' is accepted as an argument instead of the "end flag", which
causes the utility to fail because it looks for a file named '--'.