### PR TITLE
kiss: make number of packages available to hooks

### DIFF
--- a/kiss
+++ b/kiss
@@ -717,11 +717,15 @@ pkg_build_all() {
         pkg_source "$pkg"
         pkg_verify "$pkg"
     done
+    
+    # Record the total number of packages under a variable so that they are
+    # accessible to hooks.
+    pkg_total=$#
 
     # Finally build and create tarballs for all passed packages and
     # dependencies.
     for pkg do
-        log "$pkg" "Building package ($((in+=1))/$#)"
+        log "$pkg" "Building package ($((pkg_cur+=1))/$pkg_total)"
 
         pkg_find_version "$pkg"
         run_hook pre-extract "$pkg" "$pkg_dir/$pkg"


### PR DESCRIPTION
This is a follow up on https://github.com/kisslinux/kiss/issues/219. I back ported the changes from https://github.com/kiss-community/kiss/blob/master/kiss#L659-L666 to `kiss'` latest master and build some packages as test. Seems to be good on my end.