### PR TITLE
Add fossil support

### DIFF
--- a/kiss
+++ b/kiss
@@ -1376,6 +1376,59 @@ pkg_install() {
     log "$pkg_name" "Installed successfully"
 }
 
+repository_update_git() {
+    # Go to the repository's root directory.
+    git_root=$(git rev-parse --show-toplevel)
+    cd "${git_root:?"failed to find git root for '$PWD'"}"
+
+    # Go to the real root directory if this is a submodule.
+    git_root=$(git rev-parse --show-superproject-working-tree)
+    cd "${git_root:-"$PWD"}"
+
+    contains "$repos" "$PWD" || {
+        repos="$repos $PWD "
+
+        # Display a tick if signing is enabled for this repository.
+        case $(git config merge.verifySignatures) in
+            true) log "$PWD" "[signed] " ;;
+            *)    log "$PWD" " " ;;
+        esac
+
+        if [ -w "$PWD" ] && [ "$uid" != 0 ]; then
+            git pull
+            git submodule update --remote --init -f
+
+        else
+            [ "$uid" = 0 ] || log "$PWD" "Need root to update"
+
+            # Find out the owner of the repository and spawn
+            # git as this user below.
+            #
+            # This prevents 'git' from changing the original
+            # ownership of files and directories in the rare
+            # case that the repository is owned by a 3rd user.
+            file_owner "$PWD"
+
+            # We're in a repository which is owned by a 3rd
+            # user. Not root or the current user.
+            [ "$user" = root ] || log "Dropping to $user for pull"
+
+            as_root git pull
+            as_root git submodule update --remote --init -f
+        fi
+    }
+}
+
+repository_update_fossil() {
+    if [ -w "$PWD" ] && [ "$uid" != 0 ]; then
+        fossil pull
+        fossil update
+    else
+        as_root fossil pull
+        as_root fossil update
+    fi
+}
+
 pkg_updates() {
     # Check all installed packages for updates. So long as the installed
     # version and the version in the repositories differ, it's considered
@@ -1400,52 +1453,16 @@ pkg_updates() {
 
         cd "$repo"
 
-        git remote >/dev/null 2>&1 || {
-            log "$repo" " "
-            printf 'Skipping git pull, not a repository\n'
+        if git remote >/dev/null 2>&1; then
+            repository_update_git
+        elif
+            fossil info >/dev/null 2>&1; then
+            repository_update_fossil
+        else
+            printf 'Not a version controlled repository\n'
             continue
-        }
+        fi
 
-        # Go to the repository's root directory.
-        git_root=$(git rev-parse --show-toplevel)
-        cd "${git_root:?"failed to find git root for '$PWD'"}"
-
-        # Go to the real root directory if this is a submodule.
-        git_root=$(git rev-parse --show-superproject-working-tree)
-        cd "${git_root:-"$PWD"}"
-
-        contains "$repos" "$PWD" || {
-            repos="$repos $PWD "
-
-            # Display a tick if signing is enabled for this repository.
-            case $(git config merge.verifySignatures) in
-                true) log "$PWD" "[signed] " ;;
-                *)    log "$PWD" " " ;;
-            esac
-
-            if [ -w "$PWD" ] && [ "$uid" != 0 ]; then
-                git pull
-                git submodule update --remote --init -f
-
-            else
-                [ "$uid" = 0 ] || log "$PWD" "Need root to update"
-
-                # Find out the owner of the repository and spawn
-                # git as this user below.
-                #
-                # This prevents 'git' from changing the original
-                # ownership of files and directories in the rare
-                # case that the repository is owned by a 3rd user.
-                file_owner "$PWD"
-
-                # We're in a repository which is owned by a 3rd
-                # user. Not root or the current user.
-                [ "$user" = root ] || log "Dropping to $user for pull"
-
-                as_root git pull
-                as_root git submodule update --remote --init -f
-            fi
-        }
     done
 
     log "Checking for new package versions"

--- a/kiss
+++ b/kiss
@@ -270,6 +270,10 @@ pkg_source_resolve() {
     elif [ -z "${2##git+*}" ]; then
         _res=$2
 
+    # Fossil repository
+    elif [ -z "${2##fossil+*}" ]; then
+        _res=$2
+
     # Remote source (cached).
     elif [ -f "$src_dir/$1/${3:+"$3/"}${2##*/}" ]; then
         _res=$src_dir/$1/${3:+"$3/"}${2##*/}
@@ -376,6 +380,17 @@ pkg_extract_tar_hack() {
     done
 }
 
+pkg_extract_git() {
+    git init
+    git remote add origin "${1%[#@]*}"
+    git fetch -t --filter=tree:0 origin "$2" || git fetch -t
+    git -c advice.detachedHead=0 checkout "${2:-FETCH_HEAD}"
+}
+
+pkg_extract_fossil() {
+    fossil open -f "${1%[#@]*}" "${2:-trunk}"
+}
+
 pkg_extract() {
     # Extract all source archives to the build directory and copy over any
     # local repository files.
@@ -393,18 +408,16 @@ pkg_extract() {
         pkg_source_resolve "$1" "$src" "$dest" >/dev/null
 
         case $_res in
-            git+*)
+            git+*|fossil+*)
+                vcs=${src%%+*}
                 # Split the source into URL + OBJECT (branch or commit).
-                url=${src##git+} com=${url##*[@#]} com=${com#${url%[#@]*}}
+                url=${src##${vcs}+} com=${url##*[@#]} com=${com#${url%[#@]*}}
 
                 # This magic will shallow clone branches, commits or the
                 # regular repository. It correctly handles cases where a
                 # shallow clone is not possible.
                 log "$1" "Cloning ${url%[#@]*}"
-                git init
-                git remote add origin "${url%[#@]*}"
-                git fetch -t --filter=tree:0 origin "$com" || git fetch -t
-                git -c advice.detachedHead=0 checkout "${com:-FETCH_HEAD}"
+                "pkg_extract_$vcs" "${url%[#@]*}" "$com"
             ;;
 
             *.tar|*.tar.??|*.tar.???|*.tar.????|*.t?z)


### PR DESCRIPTION
Mostly just some cut and paste to segregate `git` to its own functions (one for package cloning, one for repository updates) and adding an analogous function for `fossil`. 

I've briefly tested it -- it updates repositories and prompts for updates, it clones repositories/branches/commits and builds packages.

We could add more things to this or simplify it some if you would like!