### PR TITLE
fix nonexistent directory

### DIFF
--- a/kiss
+++ b/kiss
@@ -930,6 +930,7 @@ pkg_verify() {
     done 2>/dev/null < "$repo_dir/checksums"
 
     # Generate a new set of checksums to compare against.
+    mkdir -p "$mak_dir"
     pkg_checksums "$1" > "$mak_dir/v"
 
     # Check that the first column (separated by whitespace) match in both


### PR DESCRIPTION
There is a bug when building new packages.
```
/usr/bin/kiss: line 933: can't create /root/.cache/kiss/proc/813465/build/v: nonexistent directory
```
line 993: (`pkg_verify`)
```sh
pkg_checksums "$1" > "$mak_dir/v"
```

My analysis:

`pkg_verify` is called before `pkg_build` in `pkg_build_all`. And because `$mak_dir` is created in `pkg_build`, `pkg_verify` throws an error on line 993 when trying to create a file inside `$mak_dir`.

but I could be wrong.

I tested this patch by installing another few new packages and the bug didn't occur again.