### PR TITLE
kiss-outdated: check repology in parallel

### DIFF
--- a/contrib/kiss-outdated
+++ b/contrib/kiss-outdated
@@ -16,7 +16,7 @@ for repo do
 
 for pkg in */; do
     pkg=${pkg%%/}
-    echo $pkg
+    echo "$pkg"
 done | xargs -P"$(nproc)" -I{} sh -c "
 repology_version() {
     # Grab the package's version as known by repology.org by downloading the
@@ -287,5 +287,5 @@ aux() {
 }
 aux {}
 " | sort
-    cd $OLDPWD || exit 1
+    cd "$OLDPWD" || exit 1
 done

--- a/contrib/kiss-outdated
+++ b/contrib/kiss-outdated
@@ -1,25 +1,42 @@
 #!/bin/sh
 # Check repository for outdated packages
 
+for repo do
+    [ "$repo" ] || {
+        printf 'usage: kiss outdated /path/to/repo\n' >&2
+        exit 1
+    }
+
+    cd "$repo" 2>/dev/null || {
+        printf 'repository %s is inaccessible\n' "$repo" >&2
+        exit 1
+    }
+
+    printf '\n[Checking Repology for outdated packages in %s]\n\n' "${repo%%/}" >&2
+
+for pkg in */; do
+    pkg=${pkg%%/}
+    echo $pkg
+done | xargs -P"$(nproc)" -I{} sh -c "
 repology_version() {
     # Grab the package's version as known by repology.org by downloading the
     # svg latest-version badge and extracting the version from the xml.
-    repology_name "$1"
+    repology_name \"\$1\"
 
-    r=$(curl -Ss "https://repology.org/badge/latest-versions/$remote.svg") && {
-        remote_ver=${r%</text>*}
-        remote_ver=${remote_ver##*>}
+    r=\$(curl -Ss \"https://repology.org/badge/latest-versions/\$remote.svg\") && {
+        remote_ver=\${r%</text>*}
+        remote_ver=\${remote_ver##*>}
     }
 }
 
 repology_name() {
     # Fix any known naming inconsistences between packages and Repology.
-    remote=$(
+    remote=\$(
         # Strip unrelated suffixes.
-        remote=${1%%-bin}
-        remote=${remote%%-git}
+        remote=\${1%%-bin}
+        remote=\${remote%%-git}
 
-        printf %s "$remote" |
+        printf %s \"\$remote\" |
 
         # Remote names are all lowercase.
         tr '[:upper:]' '[:lower:]' |
@@ -28,7 +45,7 @@ repology_name() {
         tr _ -
     )
 
-    case $remote in
+    case \$remote in
         baseinit|baselayout|kiss)
             remote=-
         ;;
@@ -91,7 +108,7 @@ repology_name() {
         ;;
 
         gst-*)
-            remote=gstreamer:${remote##*-}
+            remote=gstreamer:\${remote##*-}
         ;;
 
         gtar)
@@ -125,7 +142,7 @@ repology_name() {
 
         libmupdf | libxaw3d)
             # TODO [community]: Rename packages?
-            remote=${remote##lib}
+            remote=\${remote##lib}
         ;;
 
         links2)
@@ -220,7 +237,7 @@ repology_name() {
         ;;
 
         xf86-*)
-            remote=xdrv:${remote##*-}
+            remote=xdrv:\${remote##*-}
         ;;
 
         xmlsec1)
@@ -230,32 +247,29 @@ repology_name() {
     esac
 }
 
-main() {
-    printf '\n[Checking Repology for outdated packages in %s]\n\n' "${1%%/}" >&2
+aux() {
+        pkg=\$1
 
-    for pkg in */; do
-        pkg=${pkg%%/}
-
-        read -r ver _ 2>/dev/null < "$pkg/version" || {
-            printf '%-30s local version not found\n' "$pkg" >&2
+        read -r ver _ 2>/dev/null < \"\$pkg/version\" || {
+            printf '%-30s local version not found\n' \"\$pkg\" >&2
             continue
         }
 
-        [ "$ver" = git ] &&
+        [ \"\$ver\" = git ] &&
             continue
 
-        repology_version "$pkg" || {
-            printf '%-30s network error\n' "$pkg" >&2
+        repology_version \"\$pkg\" || {
+            printf '%-30s network error\n' \"\$pkg\" >&2
             continue
         }
 
-        case $remote_ver in
-            *", $ver"* | *"$ver,"* | "$ver")
+        case \$remote_ver in
+            *\", \$ver\"* | *\"\$ver,\"* | \"\$ver\")
                 # Package up-to-date, do nothing.
             ;;
 
             '' | ' ')
-                printf '\n%s: empty response\n' "$pkg" >&2
+                printf '\n%s: empty response\n' \"\$pkg\" >&2
                 printf 'possible causes:\n' >&2
                 printf '    package name differs from repology name,\n' >&2
                 printf '    package not tracked by repology,\n' >&2
@@ -267,23 +281,11 @@ main() {
             ;;
 
             *)
-                printf '%-30s %s -> %s\n' "$pkg" "$ver" "$remote_ver"
+                printf '%-30s %s -> %s\n' \"\$pkg\" \"\$ver\" \"\$remote_ver\"
             ;;
         esac
-    done
 }
-
-for repo do
-    [ "$repo" ] || {
-        printf 'usage: kiss outdated /path/to/repo\n' >&2
-        exit 1
-    }
-
-    cd "$repo" 2>/dev/null || {
-        printf 'repository %s is inaccessible\n' "$repo" >&2
-        exit 1
-    }
-
-    main "$repo"
-    cd "$OLDPWD" || exit 1
+aux {}
+" | sort
+    cd $OLDPWD || exit 1
 done


### PR DESCRIPTION
The biggest change from the original implementation is that chekcing for
updates is now done in parallel via xargs. This provides a massive speed
increase for even small repositories.

Old times:
core  -   17.141s
extra - 1m29.778s

New times:
core  -   1.689s
extra -   4.246s

Where 'core' and 'extra' are the core and extra repositories in the main
kisslinux repo.

One thing that is regressed in this patch is the maintainability of
kiss-outdated is now reduced, as much of the script is now contained as a
string argument. Ideally this could be fixed by splitting up the script
to be two new scripts.