### PR TITLE
Don't parse output of 'ls'

### DIFF
--- a/kiss
+++ b/kiss
@@ -120,14 +120,7 @@ fnr() {
 am_owner() {
     # Figure out if we need to change users to operate on
     # a given file or directory.
-    inf=$(ls -ld "$1") ||
-        die "Failed to file information for '$1'"
-
-    # Split the ls output into fields.
-    read -r _ _ user _ <<EOF
-$inf
-EOF
-
+    user="$(stat -c %U "$1")"
     equ "$LOGNAME/$user" "$user/$LOGNAME"
 }
 
@@ -1228,28 +1221,7 @@ pkg_swap() {
 }
 
 file_rwx() {
-    # Convert the output of 'ls' (rwxrwx---) to octal. This is simply
-    # a 1-9 loop with the second digit being the value of the field.
-    #
-    # NOTE: This drops setgid/setuid permissions and does not include
-    # them in the conversion. This is intentional.
-    unset oct o
-
-    rwx=$(ls -ld "$1")
-
-    for c in 14 22 31 44 52 61 74 82 91; do
-        rwx=${rwx#?}
-
-        case $rwx in
-            [rwx]*) o=$((o + ${c#?})) ;;
-             [st]*) o=$((o + 1)) ;;
-        esac
-
-        case $((${c%?} % 3)) in 0)
-            oct=$oct$o
-            o=0
-        esac
-    done
+    oct="$(stat -c %a "$1")"
 }
 
 pkg_install_files() {


### PR DESCRIPTION
Parsing the output of `ls` is considered bad practice, use `stat` to get the file owner and permissions instead.