### PR TITLE
kiss-rrevdepends: added new utility

### DIFF
--- a/contrib/kiss-rrevdepends
+++ b/contrib/kiss-rrevdepends
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# kiss-rrevdepends (repo-revdepends)
+# kiss-revdepends, execpt for packages in your $KISS_PATH
+
+for repo in $(echo $KISS_PATH | tr ':' ' ')
+do
+	for pkg in $repo/*
+	do
+		(
+			if grep -sq "$1" "$pkg/depends" ; then
+				echo $pkg
+			fi
+		) &
+	done
+done
+wait

--- a/contrib/kiss-rrevdepends
+++ b/contrib/kiss-rrevdepends
@@ -3,13 +3,13 @@
 # kiss-rrevdepends (repo-revdepends)
 # kiss-revdepends, execpt for packages in your $KISS_PATH
 
-for repo in $(echo $KISS_PATH | tr ':' ' ')
+for repo in $(echo "$KISS_PATH" | tr ':' ' ')
 do
-	for pkg in $repo/*
+	for pkg in "$repo"/*
 	do
 		(
 			if grep -sq "$1" "$pkg/depends" ; then
-				echo $pkg
+				echo "$pkg"
 			fi
 		) &
 	done


### PR DESCRIPTION
Added 'kiss-rrevdepends', which functions similarly to kiss-revdepends,
except that it lists out packages in your KISS_PATH instead of packages
that you have installed.