### PR TITLE
kiss-revdepends: print only exact matches

### DIFF
--- a/contrib/kiss-revdepends
+++ b/contrib/kiss-revdepends
@@ -5,4 +5,4 @@
 
 cd "$KISS_ROOT/var/db/kiss/installed"
 
-grep "^$1" -- */depends
+grep -E "^$1( |$)" -- */depends


### PR DESCRIPTION
The ERE matches the package name, followed by either a space character
or an end-of-line. This prevents matching packages whose names contain
the target name. A word boundary '\\>' is not used, because this matches
a hyphen '-' and not end-of-lines. The end-of-line anchor '$' cannot be
used in a bracket expression.