### PR TITLE
Faster conflict detection

### DIFF
--- a/kiss
+++ b/kiss
@@ -1118,7 +1118,7 @@ pkg_conflicts() {
     # Store the list of found conflicts in a file as we'll be using the
     # information multiple times. Storing things in the cache dir allows
     # us to be lazy as they'll be automatically removed on script end.
-    grep -Fxf "$_tmp_file_pre" -- "$@" 2>/dev/null > "$_tmp_file" || :
+    sed '/\/$/d' "$@" | sort "$_tmp_file_pre" - | uniq -d > "$_tmp_file" ||:
 
     # Enable alternatives automatically if it is safe to do so.
     # This checks to see that the package that is about to be installed
@@ -1147,7 +1147,7 @@ pkg_conflicts() {
         # this work.
         #
         # Pretty nifty huh?
-        while IFS=: read -r _ con; do
+        while read -r con; do
             printf '%s\n' "Found conflict $con"
 
             # Create the "choices" directory inside of the tarball.


### PR DESCRIPTION
Replace the use of grep to determine the unique dependencies with
sort/comm.

While testing this discovered that a bug when generating the list of
conflicts. If we had a list like "A B C", where B is the current
package, we'd search " A B C " for " B " and replace it with "" so we'd
end up with " AC " which is incorrect. That code has been modified to
replace with " " such that we'd keep A and C separate.