### PR TITLE
Source kiss_hooks

### DIFF
--- a/kiss
+++ b/kiss
@@ -169,7 +169,7 @@ run_hook() {
     IFS=:
 
     for hook in ${KISS_HOOK:-}; do case $hook in *?*)
-        "$hook" "$@" || die "$1 hook failed: '$hook'"
+        IFS=" " . "$hook" || die "$1 hook failed: '$hook'"
     esac done
 
     unset IFS


### PR DESCRIPTION
Source hooks rather than running them in a separate shell. This restores
the ability to modify environmental variables like CC from hooks.

My specific use case is to be able to change compilers from tcc to gcc depending on the package because some programs don't compile with tcc.