### PR TITLE
kiss-chroot: avoid clobbering resolv.conf and continue cleanup even if umount fails

### DIFF
--- a/contrib/kiss-chroot
+++ b/contrib/kiss-chroot
@@ -16,8 +16,9 @@ run() {
 }
 
 clean() {
+    set +e
     log Unmounting host filesystems; {
-        run umount "$1/dev/shm"
+        run umount "$1/dev/shm" 2>/dev/null
         run umount "$1/dev/pts"
         run umount "$1/dev"
         run umount "$1/proc"
@@ -63,7 +64,7 @@ main() {
     log Mounting host filesystems; {
         mmount "$1/dev"     -o bind  /dev
         mmount "$1/dev/pts" -o bind /dev/pts
-        mmount "$1/dev/shm" -t tmpfs shmfs
+        mmount "$1/dev/shm" -t tmpfs shmfs 2>/dev/null
         mmount "$1/proc"    -t proc  proc
         mmount "$1/run"     -t tmpfs tmpfs
         mmount "$1/sys"     -t sysfs sys

--- a/contrib/kiss-chroot
+++ b/contrib/kiss-chroot
@@ -25,10 +25,7 @@ clean() {
         run umount "$1/sys/firmware/efi/efivars" 2>/dev/null
         run umount "$1/sys"
         run umount "$1/tmp"
-    }
-
-    log Cleaning leftover host files; {
-        run rm -f "$1/etc/resolv.conf"
+        run umount "$1/etc/resolv.conf"
     }
 }
 
@@ -62,6 +59,7 @@ main() {
 
     trap 'clean "${1%"${1##*[!/]}"}"' EXIT INT
 
+    touch "$1/etc/resolv.conf"
     log Mounting host filesystems; {
         mmount "$1/dev"     -o bind  /dev
         mmount "$1/dev/pts" -o bind /dev/pts
@@ -71,10 +69,7 @@ main() {
         mmount "$1/sys"     -t sysfs sys
         mmount "$1/sys/firmware/efi/efivars" -t efivarfs efivarfs 2>/dev/null
         mmount "$1/tmp"     -o mode=1777,nosuid,nodev -t tmpfs tmpfs
-    }
-
-    log Copying /etc/resolv.conf from host; {
-        run cp -f /etc/resolv.conf "$1/etc"
+        mmount "$1/etc/resolv.conf" -o bind /etc/resolv.conf
     }
 
     log Entering chroot; {


### PR DESCRIPTION
This PR contains the following fixes for kiss-chroot
    kiss-chroot: avoid clobbering resolv.conf

    Instead of forcibly overriding the target's resolv.conf, just bind mount
    over it. resolv.conf doesn't have to be dynamically generated so the
    previous behavior is dangerous.

And

    kiss-chroot: continue cleanup even if umount fails

    Not every specified directory may have been mounted and in such a case
    umount will fail to unmount the dir. Previously this would lead to the
    cleanup code existing prematurely and leaving some paths still mounted.
    Now these errors are silently ignored.
