### PR TITLE
Silently ignore input when alternative is already active

### DIFF
--- a/kiss
+++ b/kiss
@@ -1208,8 +1208,10 @@ pkg_swap() {
 
     fnr "$1$2" '/' '>'
 
-    [ -f "$sys_ch/$_fnr" ] || [ -h "$sys_ch/$_fnr" ] ||
-        die "Alternative '$1 ${2:-null}' doesn't exist"
+    [ -f "$sys_ch/$_fnr" ] || [ -h "$sys_ch/$_fnr" ] || {
+        [ ! -e "$2" ] && die "Alternative '$1 ${2:-null}' doesn't exist"
+        return
+    }
 
     if [ -f "$KISS_ROOT$2" ]; then
         pkg_owner "/${2#/}" ||


### PR DESCRIPTION
Previously `kiss a` would error if the alternative provided was already
in use. Now such a case is silently ignored. This is useful when there is a
post-install kiss_hook automatically and intelligently swapping
files using preferences pre-generated with kiss-preferred.