### PR TITLE
Avoid username truncation with 'stat'

### DIFF
--- a/kiss
+++ b/kiss
@@ -120,15 +120,10 @@ fnr() {
 am_owner() {
     # Figure out if we need to change users to operate on
     # a given file or directory.
-    inf=$(ls -ld "$1") ||
+    user=$(stat -c %U "$1") ||
         die "Failed to file information for '$1'"
 
-    # Split the ls output into fields.
-    read -r _ _ user _ <<EOF
-$inf
-EOF
-
-    equ "$LOGNAME/$user" "$user/$LOGNAME"
+    equ "$user" "$LOGNAME"
 }
 
 as_user() {
@@ -1230,28 +1225,13 @@ pkg_swap() {
 }
 
 file_rwx() {
-    # Convert the output of 'ls' (rwxrwx---) to octal. This is simply
-    # a 1-9 loop with the second digit being the value of the field.
-    #
-    # NOTE: This drops setgid/setuid permissions and does not include
-    # them in the conversion. This is intentional.
-    unset oct o
+    # Get the file permissions in octal using 'stat'. Then, drop
+    # setgid/setuid permissions.
+    oct=$(stat -c %a "$1")
 
-    rwx=$(ls -ld "$1")
-
-    for c in 14 22 31 44 52 61 74 82 91; do
-        rwx=${rwx#?}
-
-        case $rwx in
-            [rwx]*) o=$((o + ${c#?})) ;;
-             [st]*) o=$((o + 1)) ;;
-        esac
-
-        case $((${c%?} % 3)) in 0)
-            oct=$oct$o
-            o=0
-        esac
-    done
+    if [ $oct -gt 0777 ]; then
+   	    oct=${oct#?}
+    fi
 }
 
 pkg_install_files() {


### PR DESCRIPTION
'ls' truncates usernames containing more than eight characters, making "bibliocar" into "biblioca". I found 'stat' worked in my kiss install without any problems in place of it. I rewrote both functions that used 'ls' to make use of 'stat', instead.

While doing so, I was unsure why:
`
equ "$LOGNAME/$user" "$user/$LOGNAME"
`

wasn't:
`
equ "$user" "$LOGNAME"
`