### PR TITLE
kiss-size: fix for packages containing files with quotes in filenames

### DIFF
--- a/contrib/kiss-size
+++ b/contrib/kiss-size
@@ -29,7 +29,7 @@ kiss list "${1:-null}" >/dev/null || {
 # Directories in the manifest end in a trailing '/'.
 # Send the file list to 'xargs' to run through 'du',
 # this prevents du from exiting due to too many arguments
-sed -e "s|^|$KISS_ROOT|" -e 's|.*/$||' \
+sed -e "s|^|$KISS_ROOT|" -e '/.*\/$/d' -e 's/[^[:alnum:]]/\\&/g' \
     "$KISS_ROOT/var/db/kiss/installed/$1/manifest" \
     | xargs du -sk -- 2>/dev/null |
 


### PR DESCRIPTION
if a package contains a file with a single quote in it's name, xargs complains
about an unmatched quote and fails, and the pipeline is aborted.
this patch wraps each filename in quotes so that xargs can handle such
filenames.

rewrite of #291 to be POSIX-compliant