### PR TITLE
kiss-maintainer: fix CRUX-style usage

### DIFF
--- a/contrib/kiss-maintainer
+++ b/contrib/kiss-maintainer
@@ -7,7 +7,7 @@
     set -- "${PWD##*/}"
 }
 
-kiss search "$@" | uniq -u | while read -r repo; do cd "$repo"
+kiss search "$@" | sort -u | while read -r repo; do cd "$repo"
     m=$(git log -1 version 2>/dev/null) ||:
     m=${m##*Author: }
     m=${m%%>*}


### PR DESCRIPTION
Commit d94c811 changed `sort -u` to `uniq -u`; these are not equivalent.
`uniq -u` suppresses all duplicate lines, but `sort -u` removes all but
one. In the case of there being no command-line args, PWD is taken as
the package, and if that package is in a repo already in KISS_PATH, the
repo will be in KISS_PATH twice. This will cause the `kiss search`
command to give two entries for PWD, and `uniq -u` removes both.
Revert to `sort -u` to keep one of those entries.

If the package in PWD is not installed, there will be not entries left;
if it is installed, kiss-maintainer will try to get the history from
/var/db/kiss/installed/pkg, which is not a git repo.

Example of the incorrect behaviour:
```sh
KISS_PATH=/home/me/repo/core
PWD=/home/me/repo/core/musl
$ sh -x /usr/bin/kiss-maintainer
+ '['  ]
+ export 'KISS_PATH=/home/me/repo/core::/home/me/repo/core'
+ set -- musl
+ kiss search musl
+ uniq -u
+ read -r repo
+ read -r repo
+ cd /var/db/kiss/installed/musl
+ git log -1 version
+ m=
+ :
+ m=
+ m=
+ '['  ]
+ continue
+ read -r repo
```
(no output)