### PR TITLE
kiss: correct name of queue-status hook

### DIFF
--- a/kiss
+++ b/kiss
@@ -934,7 +934,7 @@ pkg_build_all() {
         # arg2: package name
         # arg3: number in queue
         # arg4: total in queue
-        run_hook queue "$pkg" "$_build_cur" "$#"
+        run_hook queue-status "$pkg" "$_build_cur" "$#"
 
         ! [ -f "$repo_dir/sources" ] || pkg_extract  "$pkg"
 


### PR DESCRIPTION
In the documentation at
https://github.com/kisslinux/website/blob/master/site/wiki/package-manager.txt#L197,
and in kiss itself at
https://github.com/kisslinux/kiss/blob/master/kiss#L933, the hook
executed for each package in the queue is named "queue-status", but the
argument passed to the hook has been "queue". Some users may depend on
this; either this or the documentation should be corrected to match the
other.