### PR TITLE
kiss-revdepends: only print package names

### DIFF
--- a/contrib/kiss-revdepends
+++ b/contrib/kiss-revdepends
@@ -5,5 +5,5 @@
 
 cd "$KISS_ROOT/var/db/kiss/installed"
 
-grep -E "^$1( |$)"  -- */depends
+grep -lE "^$1( |$)"  -- */depends | cut -d/ -f1
 


### PR DESCRIPTION
The only disadvantage to this is that the information about a dependency
being ` make` or not is lost, which could be reason enough not to merge this. Perhaps a patch to just print package names and optionally ` make` at the end would be better, for example:
```sh
grep -E "^$1( |$)" -- */depends | sed "s@/depends:$1@@"
```
so that output looks like
```
$ kiss revd perl
autoconf
automake
cloc
firefox          make
groff
openssl make
valgrind
xdotool make
```