### PR TITLE
write some functions in C

### DIFF
--- a/bin/kiss-size.c
+++ b/bin/kiss-size.c
@@ -1,0 +1,130 @@
+/* kiss-size.c
+ * Print the size of each file owned by a package and the total size used
+ * by the package in B, KB, or MB.
+ *
+ * Written by phoebos, 2022.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#define _POSIX_C_SOURCE
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#define PKGDB "/var/db/kiss/installed/"
+
+int
+main(int argc, char **argv) {
+    FILE *f;
+    char *pkg = argv[1];
+    char pkg_mani[PATH_MAX] = {'\0'};
+    char tmp[PATH_MAX] = {'\0'};
+    char prefix[2] = {'\0'};
+    char *kiss_root, *buf = NULL;
+    size_t buflen = 0;
+    ssize_t n, total = 0;
+
+    if (argc == 1) {
+        /* get package name from PWD */
+        char *s;
+        if (getcwd(tmp, PATH_MAX) == NULL) {
+            perror("getcwd");
+            return 1;
+        }
+        s = strrchr(tmp, '/');
+        if (s == NULL)
+            s = tmp - 1;
+        pkg = s + 1;
+    }
+
+    kiss_root = getenv("KISS_ROOT");
+    if (kiss_root)
+        strcpy(pkg_mani, kiss_root);
+
+    strcat(pkg_mani, PKGDB);
+    strcat(pkg_mani, pkg);
+    strcat(pkg_mani, "/manifest");
+    f = fopen(pkg_mani, "r");
+    if (f == NULL) {
+        fprintf(stderr, "ERROR: '%s' not found\n", pkg);
+        return 1;
+    }
+
+    if (tmp[0])
+        tmp[0] = '\0';
+    while ((n = getline(&buf, &buflen, f)) != -1) {
+        struct stat sb;
+        off_t size;
+
+        /* remove directories, which end with a '/' */
+        if (buf[n-2] == '/')
+            continue;
+
+        if (buf[n-1] == '\n')
+            buf[n-1] = '\0';
+
+        if (kiss_root != NULL) {
+            strcpy(tmp, kiss_root);
+            strcat(tmp, buf);
+        }
+
+        if (lstat(kiss_root ? tmp : buf, &sb) == -1) {
+            perror(kiss_root ? tmp : buf);
+            continue;
+        }
+
+        prefix[0] = '\0';
+        size = sb.st_size;
+        if (size > 1023) {
+            size >>= 10;
+            prefix[0] = 'K';
+            if (size > 1023) {
+                size >>= 10;
+                prefix[0] = 'M';
+            }
+        }
+
+        printf("%zu%sB\t%s\n", size, prefix[0] ? prefix : "", kiss_root ? tmp : buf);
+        total += sb.st_size;
+    }
+
+    prefix[0] = '\0';
+    if (total > 1023) {
+        total >>= 10;
+        prefix[0] = 'K';
+        if (total > 1023) {
+            total >>= 10;
+            prefix[0] = 'M';
+        }
+    }
+    fprintf(stderr, "%zu%sB\ttotal\n", total, prefix[0] ? prefix : "");
+    free(buf);
+    fclose(f);
+
+    return 0;
+}

--- a/bin/owner.c
+++ b/bin/owner.c
@@ -1,0 +1,54 @@
+/* owner.c
+ * Print the username of the owner of the path supplied as the first argument.
+ * Follows symbolic links (using stat(3)).
+ *
+ * Written by phoebos, 2022.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <pwd.h>
+#include <stdio.h>
+#include <sys/stat.h>
+
+int
+main(int argc, char **argv) {
+    struct stat sb;
+    struct passwd *pw;
+    if (argc != 2) {
+        fprintf(stderr, "usage: %s file\n", argv[0]);
+        return 1;
+    }
+    if (stat(argv[1], &sb) != 0) {
+        perror(argv[1]);
+        return 1;
+    }
+    pw = getpwuid(sb.st_uid);
+    if (pw == NULL) {
+        fprintf(stderr, "%s: %s: owner name not found\n", argv[0], argv[1]);
+        return 1;
+    }
+    printf("%s\n", pw->pw_name);
+    return 0;
+}

--- a/bin/rwx.c
+++ b/bin/rwx.c
@@ -1,0 +1,47 @@
+/* rwx.c
+ * Print the octal permissions of the path supplied as the first argument.
+ * Follows symbolic links (using stat(3)).
+ *
+ * Written by phoebos, 2022.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <sys/stat.h>
+
+int
+main(int argc, char **argv) {
+    struct stat sb;
+    if (argc != 2) {
+        fprintf(stderr, "usage: %s file\n", argv[0]);
+        return 1;
+    }
+    if (stat(argv[1], &sb) != 0) {
+        perror(argv[1]);
+        return 1;
+    }
+    printf("%o\n", sb.st_mode & 0777);
+    return 0;
+}

--- a/kiss
+++ b/kiss
@@ -120,13 +120,8 @@ fnr() {
 am_owner() {
     # Figure out if we need to change users to operate on
     # a given file or directory.
-    inf=$(ls -ld "$1") ||
+    user=$(owner "$1") ||
         die "Failed to file information for '$1'"
-
-    # Split the ls output into fields.
-    read -r _ _ user _ <<EOF
-$inf
-EOF
 
     equ "$LOGNAME/$user" "$user/$LOGNAME"
 }
@@ -1950,6 +1945,9 @@ main() {
     # Never know when you're gonna need one of these.
     newline="
 "
+
+    # Prefer our custom binary tools.
+    export PATH="/usr/lib/kiss/:$PATH"
 
     # Defaults for environment variables.
     : "${KISS_COMPRESS:=gz}"

--- a/kiss
+++ b/kiss
@@ -1225,28 +1225,9 @@ pkg_swap() {
 }
 
 file_rwx() {
-    # Convert the output of 'ls' (rwxrwx---) to octal. This is simply
-    # a 1-9 loop with the second digit being the value of the field.
-    #
-    # NOTE: This drops setgid/setuid permissions and does not include
-    # them in the conversion. This is intentional.
-    unset oct o
-
-    rwx=$(ls -ld "$1")
-
-    for c in 14 22 31 44 52 61 74 82 91; do
-        rwx=${rwx#?}
-
-        case $rwx in
-            [rwx]*) o=$((o + ${c#?})) ;;
-             [st]*) o=$((o + 1)) ;;
-        esac
-
-        case $((${c%?} % 3)) in 0)
-            oct=$oct$o
-            o=0
-        esac
-    done
+    # NOTE: This intentionally drops setgid/setuid permissions.
+    oct=$(rwx "$1") ||
+        die "Failed to find information for '$1'"
 }
 
 pkg_install_files() {


### PR DESCRIPTION
Below is one way of integrating some C programs into the package manager. At the moment they are individual binaries but in the future the `main` functions of each program could be used as self contained functions in a library. See https://github.com/kisslinux/website/blob/68db287bdf5b12e78d50c4b17f9a27c6a3d4eec6/site/blog/20210711a.txt#L261-L275 for one of Dylan's ideas.

I have not implemented the opt-in/out idea but this could be achieved with a simple environment variable check.

With these patches, the package manager expects the binaries to be found in `/usr/lib/kiss/`. A patch to support this for the kiss build file in repo is below. Either the directory `/usr/lib/kiss/` can be prepended to `$PATH`, or absolute paths could be used when the programs are called. Maybe it would be best to call the binaries `kiss_owner` etc rather than just `owner` and use them in `/usr/lib/kiss` prepended to `$PATH`.

I have started with two C programs; each replaces one instance of parsing `ls`. This fixes the problem in #289 and should be a bit faster.

Both C programs are written in ISO C90 (`-std=c89`) and use only libc functions from POSIX.

```diff
diff --git a/core/kiss/build b/core/kiss/build
index 08d78cbf..b61bbb52 100755
--- a/core/kiss/build
+++ b/core/kiss/build
@@ -2,7 +2,8 @@
 
 mkdir -p \
     "$1/usr/bin" \
-    "$1/usr/share/doc/kiss"
+    "$1/usr/lib/kiss" \
+    "$1/usr/share/doc/kiss/lib"
 
 cp -f  kiss contrib/*  "$1/usr/bin"
 cp -f  docs/site/*.txt "$1/usr/share/doc/kiss"
@@ -12,3 +13,10 @@ rm -f \
     "$1/usr/share/doc/kiss/README.txt" \
     "$1/usr/share/doc/kiss/post.txt" \
     "$1/usr/share/doc/kiss/tidbits.txt"
+
+# Disable warning as CFLAGS must work this way.
+# shellcheck disable=2086
+for bin in owner rwx; do
+    "$CC" -o "$1/usr/lib/kiss/$bin" "bin/$bin.c" $CFLAGS -static
+    cp -f "bin/$bin.c" "$1/usr/share/doc/kiss/lib/$bin.c"
+done
```

Thoughts are welcome, this is just one idea of an improvement.