### PR TITLE
kiss-chroot: fix trap

### DIFF
--- a/contrib/kiss-chroot
+++ b/contrib/kiss-chroot
@@ -57,7 +57,9 @@ main() {
     [ -d "$1" ]        || die Given path does not exist
     [ "$(id -u)" = 0 ] || die Script needs to be run as root
 
-    trap 'clean "${1%"${1##*[!/]}"}"' EXIT INT
+    # Intended behaviour.
+    # shellcheck disable=SC2064
+    trap "clean ${1%"${1##*[!/]}"}" EXIT INT
 
     log Mounting host paths; {
         mmount "$1/dev"     -o bind /dev


### PR DESCRIPTION
If the chroot is exited with nonzero status, kiss-chroot runs `die chroot failed`.
Then, die runs `exit 1` which causes the EXIT trap to
execute. However, in this scope, "$@" is "chroot failed", so the trap
evaluates $1 to be "chroot" rather than the mountpoint given to the
kiss-chroot script. Then, the trap tries to unmount "chroot/dev" etc
rather than the true mountpoint.

This patch uses double quotes rather than single when setting the trap,
so that $1 is expanded then and the mountpoint is stored for when the
trap is called.

To reproduce the bug:
```
# /mnt/bin/kiss-chroot /mnt
...
/ # exit 1
-> chroot failed.
-> Unmounting host paths.
umount chroot/dev/shm
umount chroot/dev/pts
umount: chroot/dev/pts: no mount point specified.
umount chroot/dev
umount: chroot/dev: no mount point specified.
umount chroot/proc
umount: chroot/proc: no mount point specified.
umount chroot/run
umount: chroot/run: no mount point specified.
umount chroot/sys/firmware/efi/efivars
umount chroot/sys
umount: chroot/sys: no mount point specified.
umount chroot/tmp
umount: chroot/tmp: no mount point specified.
umount chroot/etc/resolv.conf
umount: chroot/etc/resolv.conf: no mount point specified.
```