### PR TITLE
kiss: fix pkg_update for extra colons in KISS_PATH

### DIFF
--- a/kiss
+++ b/kiss
@@ -1577,6 +1577,7 @@ pkg_update() {
 
     # Update each repository in '$KISS_PATH'.
     for repo do
+        ok "$repo" || continue
         if git -C "$repo" rev-parse 'HEAD@{upstream}' >/dev/null 2>&1; then
             repo_type=git
 


### PR DESCRIPTION
If `KISS_PATH=::` or even `KISS_PATH=:/repo1:/repo2`, the `IFS=:; set -- $KISS_PATH`
trick leaves some of $@ as empty strings. These cause git to print errors.
Instead, skip empty arguments.

Demonstration of bug:

    $ cd
    $ KISS_PATH=::: kiss u 2>&1 | sed '/Checking/q'
    -> Updating repositories
    fatal: not a git repository (or any of the parent directories): .git
    fatal: not a git repository (or any of the parent directories): .git
    fatal: not a git repository (or any of the parent directories): .git
    -> Checking for new package versions

The git commands producing the errors are:

    git -C "" rev-parse 'HEAD@{upstream}'

and when the argument to -C is empty, the current working directory is
unchanged. Therefore, if PWD happens to be inside a git tree, this
command could have unexpected effects: currently, if KISS_PATH contains
(an) extra colon(s), and PWD is in a git repo with an upstream, the repo
is updated irrespective of whether it is in KISS_PATH or a package repo.
This behaviour is also fixed by this commit.