### PR TITLE
kiss: make KISS_FORCE bypass build dependency checks

### DIFF
--- a/kiss
+++ b/kiss
@@ -872,7 +872,7 @@ pkg_build_all() {
     # Mark packages passed on the command-line explicit.
     # Also resolve dependencies for all explicit packages.
     for pkg do
-        pkg_depends "$pkg" expl filter
+        equ "$KISS_FORCE" 1 || pkg_depends "$pkg" expl filter
         explicit="$explicit $pkg "
     done
 


### PR DESCRIPTION
Perhaps this is not desired, or it should use a different environment
variable, but it confused me that KISS_FORCE=1 skips dependency checks
for kiss i and kiss r, but not kiss b.

I would find this useful, for example, when testing building against a
different provider of a library or testing if a dependency is unneeded.
It's easy to work around without this by editing the depends file though.

Thoughts?